### PR TITLE
Empty string keyword value should not match any pattern

### DIFF
--- a/lib/when/interpreter.ex
+++ b/lib/when/interpreter.ex
@@ -58,14 +58,16 @@ defmodule When.Interpreter do
   # Utility
 
   defp evaluate_(error = {:error, _msg}, _r_value, _module, _func), do: error
-  defp evaluate_(l_value, error = {:error, _msg}, _module, _func), do: error
+  defp evaluate_(_l_value, error = {:error, _msg}, _module, _func), do: error
+  defp evaluate_(_pattern, "", _module, :match?), do: false
+  defp evaluate_(_pattern, "", _module, :not_match?), do: true
   defp evaluate_(l_value, r_value, module, func) do
     apply(module, func, [l_value, r_value])
   end
 
   # Helper matching function
 
-  def not_match?(pattern, string), do: not Regex.match?(~r/#{pattern}/, string)
+  def not_match?(pattern, string), do: not Regex.match?(pattern, string)
 
   ## This is rquired because both Kernel.and and Kernel.or are macros, so they can
   ## not be called directly from apply/3

--- a/test/when_test.exs
+++ b/test/when_test.exs
@@ -44,6 +44,16 @@ defmodule When.Test do
     end)
   end
 
+  test "empty string value of keyword parameter does not match '.*' regex" do
+    params = %{"branch" => "master", "tag" => ""}
+
+    assert {:ok, false} = When.evaluate("tag =~ '.*'", params)
+    assert {:ok, true}  = When.evaluate("tag !~ '.*'", params)
+
+    assert {:ok, true}  = When.evaluate("branch =~ '.*'", params)
+    assert {:ok, false} = When.evaluate("branch !~ '.*'", params)
+  end
+
   @invald_strings_parser [
     "(true and false) = 'master'",
     "'master' != (true and false)",


### PR DESCRIPTION
The problem solved here is that `'.*'` regex matches on empty string. 

E. g. if you want something not to match on any tag the most intuitive thing to write is `tag != '.*'`. 

Since tag value for builds on regular branch is an empty string, example above would be false (negation of successful regex match), even if it is expected to be true. 

The whole issue would be avoided if correct regex (`tag != '.+'`) is used, but it is not intuitive and would require of users to know that value of tag is empty string, so I think that proposed solution with hard-codded circumvention is better option then forcing this problem on users.