### PR TITLE
Functions support

### DIFF
--- a/src/when_lexer.erl
+++ b/src/when_lexer.erl
@@ -12,7 +12,7 @@
 -export([format_error/1]).
 
 %% User code. This is placed here to allow extra attributes.
--file("src/when_lexer.xrl", 20).
+-file("src/when_lexer.xrl", 37).
 
 extract_string(Chars) ->
     list_to_binary(lists:sublist(Chars, 2, length(Chars) - 2)).
@@ -312,420 +312,1402 @@ adjust_line(T, A, [_|Cs], L) ->
 %% input.
 
 -file("src/when_lexer.erl", 313).
-yystate() -> 81.
+yystate() -> 88.
 
-yystate(88, [95|Ics], Line, Tlen, Action, Alen) ->
+yystate(95, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(95, [83|Ics], Line, Tlen, _, _) ->
+    yystate(70, Ics, Line, Tlen+1, 10, Tlen);
+yystate(95, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(95, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,95};
+yystate(94, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(94, [83|Ics], Line, Tlen, _, _) ->
+    yystate(90, Ics, Line, Tlen+1, 10, Tlen);
+yystate(94, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(94, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,94};
+yystate(93, [114|Ics], Line, Tlen, _, _) ->
+    yystate(85, Ics, Line, Tlen+1, 10, Tlen);
+yystate(93, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(93, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(93, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(93, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(93, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(93, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(93, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,93};
+yystate(92, [32|Ics], Line, Tlen, _, _) ->
+    yystate(92, Ics, Line, Tlen+1, 11, Tlen);
+yystate(92, [13|Ics], Line, Tlen, _, _) ->
+    yystate(92, Ics, Line, Tlen+1, 11, Tlen);
+yystate(92, [9|Ics], Line, Tlen, _, _) ->
+    yystate(92, Ics, Line, Tlen+1, 11, Tlen);
+yystate(92, [10|Ics], Line, Tlen, _, _) ->
+    yystate(92, Ics, Line+1, Tlen+1, 11, Tlen);
+yystate(92, Ics, Line, Tlen, _, _) ->
+    {11,Tlen,Ics,Line,92};
+yystate(91, [95|Ics], Line, Tlen, _, _) ->
+    yystate(93, Ics, Line, Tlen+1, 10, Tlen);
+yystate(91, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(91, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,91};
+yystate(90, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(90, [85|Ics], Line, Tlen, _, _) ->
+    yystate(82, Ics, Line, Tlen+1, 10, Tlen);
+yystate(90, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(90, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,90};
+yystate(89, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(89, [76|Ics], Line, Tlen, _, _) ->
+    yystate(95, Ics, Line, Tlen+1, 10, Tlen);
+yystate(89, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(89, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(89, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(89, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(89, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(89, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,89};
+yystate(88, [116|Ics], Line, Tlen, Action, Alen) ->
     yystate(80, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [115|Ics], Line, Tlen, Action, Alen) ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [114|Ics], Line, Tlen, Action, Alen) ->
+    yystate(24, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [113|Ics], Line, Tlen, Action, Alen) ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [112|Ics], Line, Tlen, Action, Alen) ->
+    yystate(71, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [111|Ics], Line, Tlen, Action, Alen) ->
+    yystate(37, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [102|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [98|Ics], Line, Tlen, Action, Alen) ->
+    yystate(1, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [97|Ics], Line, Tlen, Action, Alen) ->
+    yystate(38, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [84|Ics], Line, Tlen, Action, Alen) ->
+    yystate(54, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [83|Ics], Line, Tlen, Action, Alen) ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [82|Ics], Line, Tlen, Action, Alen) ->
+    yystate(86, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [81|Ics], Line, Tlen, Action, Alen) ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [80|Ics], Line, Tlen, Action, Alen) ->
+    yystate(10, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [79|Ics], Line, Tlen, Action, Alen) ->
+    yystate(73, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [70|Ics], Line, Tlen, Action, Alen) ->
+    yystate(81, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [66|Ics], Line, Tlen, Action, Alen) ->
+    yystate(83, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [65|Ics], Line, Tlen, Action, Alen) ->
+    yystate(43, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [61|Ics], Line, Tlen, Action, Alen) ->
+    yystate(19, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [48|Ics], Line, Tlen, Action, Alen) ->
+    yystate(12, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(20, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [44|Ics], Line, Tlen, Action, Alen) ->
+    yystate(28, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [41|Ics], Line, Tlen, Action, Alen) ->
+    yystate(36, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [40|Ics], Line, Tlen, Action, Alen) ->
+    yystate(44, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [39|Ics], Line, Tlen, Action, Alen) ->
+    yystate(52, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [33|Ics], Line, Tlen, Action, Alen) ->
+    yystate(76, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(92, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [13|Ics], Line, Tlen, Action, Alen) ->
+    yystate(92, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(92, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(92, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(88, [C|Ics], Line, Tlen, Action, Alen) when C >= 49, C =< 57 ->
+    yystate(11, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [C|Ics], Line, Tlen, Action, Alen) when C >= 67, C =< 69 ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [C|Ics], Line, Tlen, Action, Alen) when C >= 71, C =< 78 ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [C|Ics], Line, Tlen, Action, Alen) when C >= 85, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [C|Ics], Line, Tlen, Action, Alen) when C >= 99, C =< 101 ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [C|Ics], Line, Tlen, Action, Alen) when C >= 103, C =< 110 ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(88, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
 yystate(88, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,88};
-yystate(87, [71|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(87, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,87};
-yystate(86, [84|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(86, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,86};
-yystate(85, [32|Ics], Line, Tlen, _, _) ->
-    yystate(85, Ics, Line, Tlen+1, 7, Tlen);
-yystate(85, [13|Ics], Line, Tlen, _, _) ->
-    yystate(85, Ics, Line, Tlen+1, 7, Tlen);
-yystate(85, [9|Ics], Line, Tlen, _, _) ->
-    yystate(85, Ics, Line, Tlen+1, 7, Tlen);
-yystate(85, [10|Ics], Line, Tlen, _, _) ->
-    yystate(85, Ics, Line+1, Tlen+1, 7, Tlen);
+yystate(87, [108|Ics], Line, Tlen, _, _) ->
+    yystate(91, Ics, Line, Tlen+1, 10, Tlen);
+yystate(87, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(87, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(87, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,87};
+yystate(86, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(86, [69|Ics], Line, Tlen, _, _) ->
+    yystate(94, Ics, Line, Tlen+1, 10, Tlen);
+yystate(86, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(86, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,86};
+yystate(85, [101|Ics], Line, Tlen, _, _) ->
+    yystate(77, Ics, Line, Tlen+1, 10, Tlen);
+yystate(85, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(85, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(85, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(85, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(85, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(85, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(85, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line,85};
-yystate(84, [83|Ics], Line, Tlen, Action, Alen) ->
-    yystate(86, Ics, Line, Tlen+1, Action, Alen);
-yystate(84, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,84};
-yystate(83, [69|Ics], Line, Tlen, Action, Alen) ->
-    yystate(49, Ics, Line, Tlen+1, Action, Alen);
-yystate(83, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,83};
-yystate(82, [108|Ics], Line, Tlen, Action, Alen) ->
-    yystate(88, Ics, Line, Tlen+1, Action, Alen);
-yystate(82, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,82};
-yystate(81, [116|Ics], Line, Tlen, Action, Alen) ->
-    yystate(73, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(25, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [112|Ics], Line, Tlen, Action, Alen) ->
-    yystate(66, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [111|Ics], Line, Tlen, Action, Alen) ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [102|Ics], Line, Tlen, Action, Alen) ->
-    yystate(16, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [98|Ics], Line, Tlen, Action, Alen) ->
-    yystate(11, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(51, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [84|Ics], Line, Tlen, Action, Alen) ->
-    yystate(67, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [82|Ics], Line, Tlen, Action, Alen) ->
-    yystate(79, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [80|Ics], Line, Tlen, Action, Alen) ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [79|Ics], Line, Tlen, Action, Alen) ->
-    yystate(78, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [70|Ics], Line, Tlen, Action, Alen) ->
-    yystate(70, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [66|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [65|Ics], Line, Tlen, Action, Alen) ->
-    yystate(2, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(21, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [41|Ics], Line, Tlen, Action, Alen) ->
-    yystate(29, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [40|Ics], Line, Tlen, Action, Alen) ->
-    yystate(37, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [39|Ics], Line, Tlen, Action, Alen) ->
-    yystate(45, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [33|Ics], Line, Tlen, Action, Alen) ->
-    yystate(69, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(85, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [13|Ics], Line, Tlen, Action, Alen) ->
-    yystate(85, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(85, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(85, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(81, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,81};
-yystate(80, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(72, Ics, Line, Tlen+1, Action, Alen);
-yystate(80, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,80};
-yystate(79, [69|Ics], Line, Tlen, Action, Alen) ->
-    yystate(71, Ics, Line, Tlen+1, Action, Alen);
-yystate(79, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,79};
-yystate(78, [82|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(78, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,78};
-yystate(77, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,85};
+yystate(84, Ics, Line, Tlen, _, _) ->
     {0,Tlen,Ics,Line};
-yystate(76, [69|Ics], Line, Tlen, Action, Alen) ->
+yystate(83, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(83, [82|Ics], Line, Tlen, _, _) ->
+    yystate(75, Ics, Line, Tlen+1, 10, Tlen);
+yystate(83, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(83, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,83};
+yystate(82, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(82, [76|Ics], Line, Tlen, _, _) ->
+    yystate(74, Ics, Line, Tlen+1, 10, Tlen);
+yystate(82, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(82, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,82};
+yystate(81, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(81, [65|Ics], Line, Tlen, _, _) ->
+    yystate(89, Ics, Line, Tlen+1, 10, Tlen);
+yystate(81, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(81, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(81, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(81, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(81, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,81};
+yystate(80, [114|Ics], Line, Tlen, _, _) ->
+    yystate(72, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, [97|Ics], Line, Tlen, _, _) ->
+    yystate(48, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 113 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(80, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,80};
+yystate(79, [108|Ics], Line, Tlen, _, _) ->
+    yystate(87, Ics, Line, Tlen+1, 10, Tlen);
+yystate(79, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(79, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(79, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,79};
+yystate(78, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(78, [71|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(78, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 70 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 72, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(78, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,78};
+yystate(77, [113|Ics], Line, Tlen, _, _) ->
+    yystate(69, Ics, Line, Tlen+1, 10, Tlen);
+yystate(77, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(77, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(77, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(77, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(77, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 112 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(77, [C|Ics], Line, Tlen, _, _) when C >= 114, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(77, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,77};
+yystate(76, [126|Ics], Line, Tlen, Action, Alen) ->
+    yystate(84, Ics, Line, Tlen+1, Action, Alen);
+yystate(76, [61|Ics], Line, Tlen, Action, Alen) ->
     yystate(84, Ics, Line, Tlen+1, Action, Alen);
 yystate(76, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,76};
-yystate(75, [85|Ics], Line, Tlen, Action, Alen) ->
-    yystate(83, Ics, Line, Tlen+1, Action, Alen);
-yystate(75, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,75};
-yystate(74, [108|Ics], Line, Tlen, Action, Alen) ->
-    yystate(82, Ics, Line, Tlen+1, Action, Alen);
-yystate(74, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,74};
-yystate(73, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(73, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(41, Ics, Line, Tlen+1, Action, Alen);
-yystate(73, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,73};
-yystate(72, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(64, Ics, Line, Tlen+1, Action, Alen);
-yystate(72, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,72};
-yystate(71, [83|Ics], Line, Tlen, Action, Alen) ->
-    yystate(63, Ics, Line, Tlen+1, Action, Alen);
-yystate(71, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,71};
-yystate(70, [65|Ics], Line, Tlen, Action, Alen) ->
-    yystate(62, Ics, Line, Tlen+1, Action, Alen);
-yystate(70, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,70};
-yystate(69, [126|Ics], Line, Tlen, Action, Alen) ->
-    yystate(77, Ics, Line, Tlen+1, Action, Alen);
-yystate(69, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(77, Ics, Line, Tlen+1, Action, Alen);
-yystate(69, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,69};
-yystate(68, [85|Ics], Line, Tlen, Action, Alen) ->
-    yystate(76, Ics, Line, Tlen+1, Action, Alen);
-yystate(68, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,68};
-yystate(67, [82|Ics], Line, Tlen, Action, Alen) ->
-    yystate(75, Ics, Line, Tlen+1, Action, Alen);
-yystate(67, [65|Ics], Line, Tlen, Action, Alen) ->
-    yystate(87, Ics, Line, Tlen+1, Action, Alen);
-yystate(67, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,67};
-yystate(66, [117|Ics], Line, Tlen, Action, Alen) ->
-    yystate(74, Ics, Line, Tlen+1, Action, Alen);
-yystate(66, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,66};
-yystate(65, [117|Ics], Line, Tlen, Action, Alen) ->
-    yystate(57, Ics, Line, Tlen+1, Action, Alen);
-yystate(65, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,65};
-yystate(64, [113|Ics], Line, Tlen, Action, Alen) ->
-    yystate(56, Ics, Line, Tlen+1, Action, Alen);
-yystate(64, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,64};
-yystate(63, [85|Ics], Line, Tlen, Action, Alen) ->
-    yystate(55, Ics, Line, Tlen+1, Action, Alen);
-yystate(63, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,63};
-yystate(62, [76|Ics], Line, Tlen, Action, Alen) ->
-    yystate(54, Ics, Line, Tlen+1, Action, Alen);
-yystate(62, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,62};
+yystate(75, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(75, [65|Ics], Line, Tlen, _, _) ->
+    yystate(67, Ics, Line, Tlen+1, 10, Tlen);
+yystate(75, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(75, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,75};
+yystate(74, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(74, [84|Ics], Line, Tlen, _, _) ->
+    yystate(66, Ics, Line, Tlen+1, 10, Tlen);
+yystate(74, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 83 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 85, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(74, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,74};
+yystate(73, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(73, [82|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 10, Tlen);
+yystate(73, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(73, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,73};
+yystate(72, [117|Ics], Line, Tlen, _, _) ->
+    yystate(64, Ics, Line, Tlen+1, 10, Tlen);
+yystate(72, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(72, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(72, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,72};
+yystate(71, [117|Ics], Line, Tlen, _, _) ->
+    yystate(79, Ics, Line, Tlen+1, 10, Tlen);
+yystate(71, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(71, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(71, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(71, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(71, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(71, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(71, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,71};
+yystate(70, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(70, [69|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 10, Tlen);
+yystate(70, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(70, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,70};
+yystate(69, [117|Ics], Line, Tlen, _, _) ->
+    yystate(61, Ics, Line, Tlen+1, 10, Tlen);
+yystate(69, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(69, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(69, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,69};
+yystate(68, Ics, Line, Tlen, _, _) ->
+    {7,Tlen,Ics,Line};
+yystate(67, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(67, [78|Ics], Line, Tlen, _, _) ->
+    yystate(59, Ics, Line, Tlen+1, 10, Tlen);
+yystate(67, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 79, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(67, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,67};
+yystate(66, [95|Ics], Line, Tlen, _, _) ->
+    yystate(58, Ics, Line, Tlen+1, 5, Tlen);
+yystate(66, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(66, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,66};
+yystate(65, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(65, [84|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(65, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 83 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 85, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(65, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,65};
+yystate(64, [101|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 10, Tlen);
+yystate(64, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(64, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(64, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,64};
+yystate(63, [110|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(63, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(63, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(63, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,63};
+yystate(62, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(62, [85|Ics], Line, Tlen, _, _) ->
+    yystate(70, Ics, Line, Tlen+1, 10, Tlen);
+yystate(62, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(62, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,62};
+yystate(61, [101|Ics], Line, Tlen, _, _) ->
+    yystate(53, Ics, Line, Tlen+1, 10, Tlen);
+yystate(61, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(61, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(61, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line};
-yystate(60, [81|Ics], Line, Tlen, Action, Alen) ->
+    {10,Tlen,Ics,Line,61};
+yystate(60, [39|Ics], Line, Tlen, Action, Alen) ->
     yystate(68, Ics, Line, Tlen+1, Action, Alen);
+yystate(60, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(60, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
+    yystate(60, Ics, Line, Tlen+1, Action, Alen);
+yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 38 ->
+    yystate(60, Ics, Line, Tlen+1, Action, Alen);
+yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 40 ->
+    yystate(60, Ics, Line, Tlen+1, Action, Alen);
 yystate(60, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,60};
-yystate(59, [100|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(59, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,59};
-yystate(58, [110|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,58};
-yystate(57, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(49, Ics, Line, Tlen+1, Action, Alen);
-yystate(57, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,57};
-yystate(56, [117|Ics], Line, Tlen, Action, Alen) ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(56, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,56};
-yystate(55, [76|Ics], Line, Tlen, Action, Alen) ->
-    yystate(47, Ics, Line, Tlen+1, Action, Alen);
-yystate(55, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,55};
-yystate(54, [83|Ics], Line, Tlen, Action, Alen) ->
-    yystate(83, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,54};
-yystate(53, [39|Ics], Line, Tlen, Action, Alen) ->
-    yystate(61, Ics, Line, Tlen+1, Action, Alen);
-yystate(53, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(53, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(53, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
-    yystate(53, Ics, Line, Tlen+1, Action, Alen);
-yystate(53, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 38 ->
-    yystate(53, Ics, Line, Tlen+1, Action, Alen);
-yystate(53, [C|Ics], Line, Tlen, Action, Alen) when C >= 40 ->
-    yystate(53, Ics, Line, Tlen+1, Action, Alen);
-yystate(53, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,53};
-yystate(52, [69|Ics], Line, Tlen, Action, Alen) ->
+yystate(59, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, [67|Ics], Line, Tlen, _, _) ->
+    yystate(51, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, [65|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, [66|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 68, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(59, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,59};
+yystate(58, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(58, [82|Ics], Line, Tlen, _, _) ->
+    yystate(50, Ics, Line, Tlen+1, 10, Tlen);
+yystate(58, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(58, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,58};
+yystate(57, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(57, [83|Ics], Line, Tlen, _, _) ->
+    yystate(65, Ics, Line, Tlen+1, 10, Tlen);
+yystate(57, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(57, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,57};
+yystate(56, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
+yystate(56, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
+yystate(56, Ics, Line, Tlen, _, _) ->
+    {6,Tlen,Ics,Line,56};
+yystate(55, [111|Ics], Line, Tlen, _, _) ->
+    yystate(63, Ics, Line, Tlen+1, 10, Tlen);
+yystate(55, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(55, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(55, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,55};
+yystate(54, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, [82|Ics], Line, Tlen, _, _) ->
+    yystate(62, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, [65|Ics], Line, Tlen, _, _) ->
+    yystate(78, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 81 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(54, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,54};
+yystate(53, [115|Ics], Line, Tlen, _, _) ->
+    yystate(45, Ics, Line, Tlen+1, 10, Tlen);
+yystate(53, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(53, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(53, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,53};
+yystate(52, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(60, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(52, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
+    yystate(60, Ics, Line, Tlen+1, Action, Alen);
+yystate(52, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 38 ->
+    yystate(60, Ics, Line, Tlen+1, Action, Alen);
+yystate(52, [C|Ics], Line, Tlen, Action, Alen) when C >= 40 ->
     yystate(60, Ics, Line, Tlen+1, Action, Alen);
 yystate(52, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,52};
-yystate(51, [110|Ics], Line, Tlen, Action, Alen) ->
-    yystate(59, Ics, Line, Tlen+1, Action, Alen);
-yystate(51, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,51};
-yystate(50, [111|Ics], Line, Tlen, Action, Alen) ->
-    yystate(58, Ics, Line, Tlen+1, Action, Alen);
-yystate(50, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,50};
+yystate(51, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(51, [72|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(51, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 71 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 73, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(51, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,51};
+yystate(50, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(50, [69|Ics], Line, Tlen, _, _) ->
+    yystate(42, Ics, Line, Tlen+1, 10, Tlen);
+yystate(50, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(50, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,50};
+yystate(49, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [69|Ics], Line, Tlen, _, _) ->
+    yystate(57, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(49, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line};
-yystate(48, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(40, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,48};
-yystate(47, [84|Ics], Line, Tlen, Action, Alen) ->
-    yystate(39, Ics, Line, Tlen+1, Action, Alen);
-yystate(47, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,47};
-yystate(46, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(50, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,46};
-yystate(45, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(53, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(45, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
-    yystate(53, Ics, Line, Tlen+1, Action, Alen);
-yystate(45, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 38 ->
-    yystate(53, Ics, Line, Tlen+1, Action, Alen);
-yystate(45, [C|Ics], Line, Tlen, Action, Alen) when C >= 40 ->
-    yystate(53, Ics, Line, Tlen+1, Action, Alen);
-yystate(45, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,45};
-yystate(44, [82|Ics], Line, Tlen, Action, Alen) ->
-    yystate(52, Ics, Line, Tlen+1, Action, Alen);
-yystate(44, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,44};
-yystate(43, [104|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(43, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,43};
-yystate(42, [82|Ics], Line, Tlen, Action, Alen) ->
-    yystate(34, Ics, Line, Tlen+1, Action, Alen);
-yystate(42, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,42};
-yystate(41, [103|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(41, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,41};
-yystate(40, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(40, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,40};
-yystate(39, [95|Ics], Line, Tlen, _, _) ->
-    yystate(31, Ics, Line, Tlen+1, 4, Tlen);
-yystate(39, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,39};
-yystate(38, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(38, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,38};
-yystate(37, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,49};
+yystate(48, [103|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(48, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(48, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(48, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,48};
+yystate(47, [115|Ics], Line, Tlen, _, _) ->
+    yystate(55, Ics, Line, Tlen+1, 10, Tlen);
+yystate(47, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(47, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(47, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,47};
+yystate(46, [100|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 10, Tlen);
+yystate(46, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(46, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 99 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 101, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(46, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,46};
+yystate(45, [116|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(45, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(45, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(45, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,45};
+yystate(44, Ics, Line, Tlen, _, _) ->
     {2,Tlen,Ics,Line};
-yystate(36, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(44, Ics, Line, Tlen+1, Action, Alen);
-yystate(36, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,36};
-yystate(35, [99|Ics], Line, Tlen, Action, Alen) ->
-    yystate(43, Ics, Line, Tlen+1, Action, Alen);
-yystate(35, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,35};
-yystate(34, [65|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(34, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,34};
-yystate(33, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line};
-yystate(32, [116|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,32};
-yystate(31, [82|Ics], Line, Tlen, Action, Alen) ->
-    yystate(23, Ics, Line, Tlen+1, Action, Alen);
-yystate(31, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,31};
-yystate(30, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(38, Ics, Line, Tlen+1, Action, Alen);
-yystate(30, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,30};
-yystate(29, Ics, Line, Tlen, _, _) ->
+yystate(43, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(43, [78|Ics], Line, Tlen, _, _) ->
+    yystate(35, Ics, Line, Tlen+1, 10, Tlen);
+yystate(43, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 79, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(43, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,43};
+yystate(42, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(42, [65|Ics], Line, Tlen, _, _) ->
+    yystate(34, Ics, Line, Tlen+1, 10, Tlen);
+yystate(42, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(42, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,42};
+yystate(41, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [85|Ics], Line, Tlen, _, _) ->
+    yystate(49, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,41};
+yystate(40, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(40, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(40, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,40};
+yystate(39, [97|Ics], Line, Tlen, _, _) ->
+    yystate(47, Ics, Line, Tlen+1, 10, Tlen);
+yystate(39, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(39, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(39, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,39};
+yystate(38, [110|Ics], Line, Tlen, _, _) ->
+    yystate(46, Ics, Line, Tlen+1, 10, Tlen);
+yystate(38, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(38, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(38, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,38};
+yystate(37, [114|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 10, Tlen);
+yystate(37, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(37, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(37, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,37};
+yystate(36, Ics, Line, Tlen, _, _) ->
     {3,Tlen,Ics,Line};
-yystate(28, [76|Ics], Line, Tlen, Action, Alen) ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(28, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,28};
-yystate(27, [110|Ics], Line, Tlen, Action, Alen) ->
-    yystate(35, Ics, Line, Tlen+1, Action, Alen);
-yystate(27, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,27};
-yystate(26, [78|Ics], Line, Tlen, Action, Alen) ->
-    yystate(18, Ics, Line, Tlen+1, Action, Alen);
-yystate(26, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,26};
-yystate(25, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(17, Ics, Line, Tlen+1, Action, Alen);
-yystate(25, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,25};
-yystate(24, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,24};
-yystate(23, [69|Ics], Line, Tlen, Action, Alen) ->
-    yystate(15, Ics, Line, Tlen+1, Action, Alen);
-yystate(23, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,23};
-yystate(22, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(22, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,22};
-yystate(21, [126|Ics], Line, Tlen, _, _) ->
-    yystate(77, Ics, Line, Tlen+1, 0, Tlen);
+yystate(35, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(35, [68|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 10, Tlen);
+yystate(35, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 67 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 69, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(35, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,35};
+yystate(34, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(34, [83|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 10, Tlen);
+yystate(34, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(34, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,34};
+yystate(33, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [81|Ics], Line, Tlen, _, _) ->
+    yystate(41, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 80 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 82, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,33};
+yystate(32, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(32, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(32, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,32};
+yystate(31, [101|Ics], Line, Tlen, _, _) ->
+    yystate(39, Ics, Line, Tlen+1, 10, Tlen);
+yystate(31, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(31, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(31, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,31};
+yystate(30, [104|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(30, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(30, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 103 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 105, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(30, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,30};
+yystate(29, [97|Ics], Line, Tlen, _, _) ->
+    yystate(21, Ics, Line, Tlen+1, 10, Tlen);
+yystate(29, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(29, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(29, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,29};
+yystate(28, Ics, Line, Tlen, _, _) ->
+    {4,Tlen,Ics,Line};
+yystate(27, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 1, Tlen);
+yystate(27, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 1, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 1, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 1, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 1, Tlen);
+yystate(27, Ics, Line, Tlen, _, _) ->
+    {1,Tlen,Ics,Line,27};
+yystate(26, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(26, [79|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 10, Tlen);
+yystate(26, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 78 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 80, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(26, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,26};
+yystate(25, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(25, [69|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
+yystate(25, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(25, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,25};
+yystate(24, [101|Ics], Line, Tlen, _, _) ->
+    yystate(16, Ics, Line, Tlen+1, 10, Tlen);
+yystate(24, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(24, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(24, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,24};
+yystate(23, [114|Ics], Line, Tlen, _, _) ->
+    yystate(31, Ics, Line, Tlen+1, 10, Tlen);
+yystate(23, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(23, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(23, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,23};
+yystate(22, [99|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, [97|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, [98|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(22, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,22};
+yystate(21, [108|Ics], Line, Tlen, _, _) ->
+    yystate(13, Ics, Line, Tlen+1, 10, Tlen);
+yystate(21, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(21, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(21, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line,21};
-yystate(20, [76|Ics], Line, Tlen, Action, Alen) ->
-    yystate(28, Ics, Line, Tlen+1, Action, Alen);
+    {10,Tlen,Ics,Line,21};
+yystate(20, [48|Ics], Line, Tlen, Action, Alen) ->
+    yystate(12, Ics, Line, Tlen+1, Action, Alen);
+yystate(20, [C|Ics], Line, Tlen, Action, Alen) when C >= 49, C =< 57 ->
+    yystate(11, Ics, Line, Tlen+1, Action, Alen);
 yystate(20, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,20};
-yystate(19, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(27, Ics, Line, Tlen+1, Action, Alen);
-yystate(19, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,19};
-yystate(18, [67|Ics], Line, Tlen, Action, Alen) ->
-    yystate(10, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,18};
-yystate(17, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(9, Ics, Line, Tlen+1, Action, Alen);
-yystate(17, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,17};
-yystate(16, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(8, Ics, Line, Tlen+1, Action, Alen);
-yystate(16, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,16};
-yystate(15, [65|Ics], Line, Tlen, Action, Alen) ->
-    yystate(7, Ics, Line, Tlen+1, Action, Alen);
-yystate(15, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,15};
+yystate(19, [126|Ics], Line, Tlen, _, _) ->
+    yystate(84, Ics, Line, Tlen+1, 0, Tlen);
+yystate(19, Ics, Line, Tlen, _, _) ->
+    {0,Tlen,Ics,Line,19};
+yystate(18, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(18, [78|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 10, Tlen);
+yystate(18, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 79, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(18, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,18};
+yystate(17, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(17, [82|Ics], Line, Tlen, _, _) ->
+    yystate(25, Ics, Line, Tlen+1, 10, Tlen);
+yystate(17, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(17, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,17};
+yystate(16, [115|Ics], Line, Tlen, _, _) ->
+    yystate(8, Ics, Line, Tlen+1, 10, Tlen);
+yystate(16, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(16, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(16, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,16};
+yystate(15, [95|Ics], Line, Tlen, _, _) ->
+    yystate(23, Ics, Line, Tlen+1, 5, Tlen);
+yystate(15, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
+yystate(15, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,15};
+yystate(14, [110|Ics], Line, Tlen, _, _) ->
+    yystate(22, Ics, Line, Tlen+1, 10, Tlen);
 yystate(14, [95|Ics], Line, Tlen, _, _) ->
-    yystate(22, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(14, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(14, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,14};
+    {10,Tlen,Ics,Line,14};
+yystate(13, [115|Ics], Line, Tlen, _, _) ->
+    yystate(64, Ics, Line, Tlen+1, 10, Tlen);
+yystate(13, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(13, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(13, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line};
-yystate(12, [85|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(12, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,12};
-yystate(11, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(19, Ics, Line, Tlen+1, Action, Alen);
-yystate(11, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,11};
-yystate(10, [72|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(10, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,10};
-yystate(9, [117|Ics], Line, Tlen, Action, Alen) ->
-    yystate(1, Ics, Line, Tlen+1, Action, Alen);
-yystate(9, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,9};
-yystate(8, [108|Ics], Line, Tlen, Action, Alen) ->
-    yystate(0, Ics, Line, Tlen+1, Action, Alen);
-yystate(8, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,8};
-yystate(7, [83|Ics], Line, Tlen, Action, Alen) ->
-    yystate(3, Ics, Line, Tlen+1, Action, Alen);
-yystate(7, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,7};
-yystate(6, [116|Ics], Line, Tlen, Action, Alen) ->
-    yystate(14, Ics, Line, Tlen+1, Action, Alen);
-yystate(6, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,6};
-yystate(5, [68|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(5, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,5};
-yystate(4, [78|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(4, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,4};
-yystate(3, [79|Ics], Line, Tlen, Action, Alen) ->
+    {10,Tlen,Ics,Line,13};
+yystate(12, Ics, Line, Tlen, _, _) ->
+    {8,Tlen,Ics,Line};
+yystate(11, [46|Ics], Line, Tlen, _, _) ->
+    yystate(3, Ics, Line, Tlen+1, 8, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(11, Ics, Line, Tlen+1, 8, Tlen);
+yystate(11, Ics, Line, Tlen, _, _) ->
+    {8,Tlen,Ics,Line,11};
+yystate(10, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [85|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,10};
+yystate(9, [95|Ics], Line, Tlen, _, _) ->
+    yystate(17, Ics, Line, Tlen+1, 10, Tlen);
+yystate(9, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(9, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,9};
+yystate(8, [117|Ics], Line, Tlen, _, _) ->
+    yystate(0, Ics, Line, Tlen+1, 10, Tlen);
+yystate(8, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(8, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(8, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,8};
+yystate(7, [116|Ics], Line, Tlen, _, _) ->
+    yystate(15, Ics, Line, Tlen+1, 10, Tlen);
+yystate(7, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(7, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(7, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,7};
+yystate(6, [97|Ics], Line, Tlen, _, _) ->
+    yystate(14, Ics, Line, Tlen+1, 10, Tlen);
+yystate(6, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(6, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(6, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,6};
+yystate(5, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(5, [76|Ics], Line, Tlen, _, _) ->
+    yystate(9, Ics, Line, Tlen+1, 10, Tlen);
+yystate(5, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(5, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,5};
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(4, Ics, Line, Tlen+1, 9, Tlen);
+yystate(4, Ics, Line, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,4};
+yystate(3, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
     yystate(4, Ics, Line, Tlen+1, Action, Alen);
 yystate(3, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,3};
-yystate(2, [78|Ics], Line, Tlen, Action, Alen) ->
-    yystate(5, Ics, Line, Tlen+1, Action, Alen);
-yystate(2, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,2};
-yystate(1, [108|Ics], Line, Tlen, Action, Alen) ->
-    yystate(6, Ics, Line, Tlen+1, Action, Alen);
-yystate(1, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,1};
-yystate(0, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(57, Ics, Line, Tlen+1, Action, Alen);
-yystate(0, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,0};
+yystate(2, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(2, [76|Ics], Line, Tlen, _, _) ->
+    yystate(5, Ics, Line, Tlen+1, 10, Tlen);
+yystate(2, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(2, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,2};
+yystate(1, [114|Ics], Line, Tlen, _, _) ->
+    yystate(6, Ics, Line, Tlen+1, 10, Tlen);
+yystate(1, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(1, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(1, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,1};
+yystate(0, [108|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 10, Tlen);
+yystate(0, [95|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(0, [45|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
+yystate(0, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,0};
 yystate(S, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,S}.
 
@@ -743,57 +1725,88 @@ yyaction(2, _, _, TokenLine) ->
     yyaction_2(TokenLine);
 yyaction(3, _, _, TokenLine) ->
     yyaction_3(TokenLine);
-yyaction(4, TokenLen, YYtcs, TokenLine) ->
-    TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_4(TokenChars, TokenLine);
+yyaction(4, _, _, TokenLine) ->
+    yyaction_4(TokenLine);
 yyaction(5, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_5(TokenChars, TokenLine);
 yyaction(6, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_6(TokenChars, TokenLine);
-yyaction(7, _, _, _) ->
-    yyaction_7();
+yyaction(7, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_7(TokenChars, TokenLine);
+yyaction(8, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_8(TokenChars, TokenLine);
+yyaction(9, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_9(TokenChars, TokenLine);
+yyaction(10, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_10(TokenChars, TokenLine);
+yyaction(11, _, _, _) ->
+    yyaction_11();
 yyaction(_, _, _, _) -> error.
 
 -compile({inline,yyaction_0/2}).
--file("src/when_lexer.xrl", 9).
+-file("src/when_lexer.xrl", 22).
 yyaction_0(TokenChars, TokenLine) ->
      { token, { operator, TokenLine, list_to_binary (TokenChars) } } .
 
 -compile({inline,yyaction_1/2}).
--file("src/when_lexer.xrl", 10).
+-file("src/when_lexer.xrl", 23).
 yyaction_1(TokenChars, TokenLine) ->
      { token, { bool_operator, TokenLine, to_lowercase_binary (TokenChars) } } .
 
 -compile({inline,yyaction_2/1}).
--file("src/when_lexer.xrl", 11).
+-file("src/when_lexer.xrl", 24).
 yyaction_2(TokenLine) ->
      { token, { '(', TokenLine } } .
 
 -compile({inline,yyaction_3/1}).
--file("src/when_lexer.xrl", 12).
+-file("src/when_lexer.xrl", 25).
 yyaction_3(TokenLine) ->
      { token, { ')', TokenLine } } .
 
--compile({inline,yyaction_4/2}).
--file("src/when_lexer.xrl", 13).
-yyaction_4(TokenChars, TokenLine) ->
-     { token, { keyword, TokenLine, to_lowercase_binary (TokenChars) } } .
+-compile({inline,yyaction_4/1}).
+-file("src/when_lexer.xrl", 26).
+yyaction_4(TokenLine) ->
+     { token, { ',', TokenLine } } .
 
 -compile({inline,yyaction_5/2}).
--file("src/when_lexer.xrl", 14).
+-file("src/when_lexer.xrl", 27).
 yyaction_5(TokenChars, TokenLine) ->
-     { token, { boolean, TokenLine, to_lowercase_binary (TokenChars) } } .
+     { token, { keyword, TokenLine, to_lowercase_binary (TokenChars) } } .
 
 -compile({inline,yyaction_6/2}).
--file("src/when_lexer.xrl", 15).
+-file("src/when_lexer.xrl", 28).
 yyaction_6(TokenChars, TokenLine) ->
+     { token, { boolean, TokenLine, to_lowercase_binary (TokenChars) } } .
+
+-compile({inline,yyaction_7/2}).
+-file("src/when_lexer.xrl", 29).
+yyaction_7(TokenChars, TokenLine) ->
      { token, { string, TokenLine, extract_string (TokenChars) } } .
 
--compile({inline,yyaction_7/0}).
--file("src/when_lexer.xrl", 16).
-yyaction_7() ->
+-compile({inline,yyaction_8/2}).
+-file("src/when_lexer.xrl", 30).
+yyaction_8(TokenChars, TokenLine) ->
+     { token, { integer, TokenLine, list_to_integer (TokenChars) } } .
+
+-compile({inline,yyaction_9/2}).
+-file("src/when_lexer.xrl", 31).
+yyaction_9(TokenChars, TokenLine) ->
+     { token, { float, TokenLine, list_to_float (TokenChars) } } .
+
+-compile({inline,yyaction_10/2}).
+-file("src/when_lexer.xrl", 32).
+yyaction_10(TokenChars, TokenLine) ->
+     { token, { identifier, TokenLine, to_lowercase_binary (TokenChars) } } .
+
+-compile({inline,yyaction_11/0}).
+-file("src/when_lexer.xrl", 33).
+yyaction_11() ->
      skip_token .
 
 -file("/usr/local/lib/erlang/lib/parsetools-2.1.6/include/leexinc.hrl", 313).

--- a/src/when_lexer.erl
+++ b/src/when_lexer.erl
@@ -20,6 +20,12 @@ extract_string(Chars) ->
 to_lowercase_binary(Chars) ->
     string:lowercase(list_to_binary(Chars)).
 
+to_boolean(Chars) ->
+    erlang:binary_to_existing_atom(string:lowercase(list_to_binary(Chars)), utf8).
+
+to_atom(Chars) ->
+    erlang:binary_to_atom(list_to_binary(Chars), utf8).
+
 -file("/usr/local/lib/erlang/lib/parsetools-2.1.6/include/leexinc.hrl", 14).
 
 format_error({illegal,S}) -> ["illegal characters ",io_lib:write_string(S)];
@@ -311,7 +317,7 @@ adjust_line(T, A, [_|Cs], L) ->
 %% return signal either an unrecognised character or end of current
 %% input.
 
--file("src/when_lexer.erl", 313).
+-file("src/when_lexer.erl", 319).
 yystate() -> 88.
 
 yystate(95, [95|Ics], Line, Tlen, _, _) ->
@@ -320,7 +326,7 @@ yystate(95, [83|Ics], Line, Tlen, _, _) ->
     yystate(70, Ics, Line, Tlen+1, 10, Tlen);
 yystate(95, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -336,7 +342,7 @@ yystate(94, [83|Ics], Line, Tlen, _, _) ->
     yystate(90, Ics, Line, Tlen+1, 10, Tlen);
 yystate(94, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -352,7 +358,7 @@ yystate(93, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(93, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(93, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(93, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(93, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -376,7 +382,7 @@ yystate(91, [95|Ics], Line, Tlen, _, _) ->
     yystate(93, Ics, Line, Tlen+1, 10, Tlen);
 yystate(91, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -390,7 +396,7 @@ yystate(90, [85|Ics], Line, Tlen, _, _) ->
     yystate(82, Ics, Line, Tlen+1, 10, Tlen);
 yystate(90, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -406,7 +412,7 @@ yystate(89, [76|Ics], Line, Tlen, _, _) ->
     yystate(95, Ics, Line, Tlen+1, 10, Tlen);
 yystate(89, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(89, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(89, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(89, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -498,7 +504,7 @@ yystate(87, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(87, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -514,7 +520,7 @@ yystate(86, [69|Ics], Line, Tlen, _, _) ->
     yystate(94, Ics, Line, Tlen+1, 10, Tlen);
 yystate(86, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -530,7 +536,7 @@ yystate(85, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(85, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(85, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(85, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(85, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -548,7 +554,7 @@ yystate(83, [82|Ics], Line, Tlen, _, _) ->
     yystate(75, Ics, Line, Tlen+1, 10, Tlen);
 yystate(83, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -564,7 +570,7 @@ yystate(82, [76|Ics], Line, Tlen, _, _) ->
     yystate(74, Ics, Line, Tlen+1, 10, Tlen);
 yystate(82, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -580,7 +586,7 @@ yystate(81, [65|Ics], Line, Tlen, _, _) ->
     yystate(89, Ics, Line, Tlen+1, 10, Tlen);
 yystate(81, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(81, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(81, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(81, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -596,7 +602,7 @@ yystate(80, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(80, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -612,7 +618,7 @@ yystate(79, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(79, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -628,7 +634,7 @@ yystate(78, [71|Ics], Line, Tlen, _, _) ->
     yystate(40, Ics, Line, Tlen+1, 10, Tlen);
 yystate(78, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 70 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -644,7 +650,7 @@ yystate(77, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(77, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(77, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(77, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(77, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -666,7 +672,7 @@ yystate(75, [65|Ics], Line, Tlen, _, _) ->
     yystate(67, Ics, Line, Tlen+1, 10, Tlen);
 yystate(75, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -680,7 +686,7 @@ yystate(74, [84|Ics], Line, Tlen, _, _) ->
     yystate(66, Ics, Line, Tlen+1, 10, Tlen);
 yystate(74, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 83 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -696,7 +702,7 @@ yystate(73, [82|Ics], Line, Tlen, _, _) ->
     yystate(27, Ics, Line, Tlen+1, 10, Tlen);
 yystate(73, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -712,7 +718,7 @@ yystate(72, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(72, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -728,7 +734,7 @@ yystate(71, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(71, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(71, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(71, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(71, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -744,7 +750,7 @@ yystate(70, [69|Ics], Line, Tlen, _, _) ->
     yystate(56, Ics, Line, Tlen+1, 10, Tlen);
 yystate(70, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -760,7 +766,7 @@ yystate(69, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(69, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -778,7 +784,7 @@ yystate(67, [78|Ics], Line, Tlen, _, _) ->
     yystate(59, Ics, Line, Tlen+1, 10, Tlen);
 yystate(67, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -792,7 +798,7 @@ yystate(66, [95|Ics], Line, Tlen, _, _) ->
     yystate(58, Ics, Line, Tlen+1, 5, Tlen);
 yystate(66, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
 yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
@@ -806,7 +812,7 @@ yystate(65, [84|Ics], Line, Tlen, _, _) ->
     yystate(40, Ics, Line, Tlen+1, 10, Tlen);
 yystate(65, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 83 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -822,7 +828,7 @@ yystate(64, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(64, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -838,7 +844,7 @@ yystate(63, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(63, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -854,7 +860,7 @@ yystate(62, [85|Ics], Line, Tlen, _, _) ->
     yystate(70, Ics, Line, Tlen+1, 10, Tlen);
 yystate(62, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -870,7 +876,7 @@ yystate(61, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(61, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -902,7 +908,7 @@ yystate(59, [66|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(59, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 68, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -916,7 +922,7 @@ yystate(58, [82|Ics], Line, Tlen, _, _) ->
     yystate(50, Ics, Line, Tlen+1, 10, Tlen);
 yystate(58, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -932,7 +938,7 @@ yystate(57, [83|Ics], Line, Tlen, _, _) ->
     yystate(65, Ics, Line, Tlen+1, 10, Tlen);
 yystate(57, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -946,7 +952,7 @@ yystate(56, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 6, Tlen);
 yystate(56, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 6, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 6, Tlen);
 yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 6, Tlen);
@@ -960,7 +966,7 @@ yystate(55, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(55, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -978,7 +984,7 @@ yystate(54, [65|Ics], Line, Tlen, _, _) ->
     yystate(78, Ics, Line, Tlen+1, 10, Tlen);
 yystate(54, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 81 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -994,7 +1000,7 @@ yystate(53, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(53, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1020,7 +1026,7 @@ yystate(51, [72|Ics], Line, Tlen, _, _) ->
     yystate(40, Ics, Line, Tlen+1, 10, Tlen);
 yystate(51, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 71 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1036,7 +1042,7 @@ yystate(50, [69|Ics], Line, Tlen, _, _) ->
     yystate(42, Ics, Line, Tlen+1, 10, Tlen);
 yystate(50, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1052,7 +1058,7 @@ yystate(49, [69|Ics], Line, Tlen, _, _) ->
     yystate(57, Ics, Line, Tlen+1, 10, Tlen);
 yystate(49, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1068,7 +1074,7 @@ yystate(48, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(48, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1084,7 +1090,7 @@ yystate(47, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(47, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1100,7 +1106,7 @@ yystate(46, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(46, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1116,7 +1122,7 @@ yystate(45, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(45, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1134,7 +1140,7 @@ yystate(43, [78|Ics], Line, Tlen, _, _) ->
     yystate(35, Ics, Line, Tlen+1, 10, Tlen);
 yystate(43, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1150,7 +1156,7 @@ yystate(42, [65|Ics], Line, Tlen, _, _) ->
     yystate(34, Ics, Line, Tlen+1, 10, Tlen);
 yystate(42, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1164,7 +1170,7 @@ yystate(41, [85|Ics], Line, Tlen, _, _) ->
     yystate(49, Ics, Line, Tlen+1, 10, Tlen);
 yystate(41, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1178,7 +1184,7 @@ yystate(40, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
 yystate(40, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
@@ -1192,7 +1198,7 @@ yystate(39, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(39, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1206,7 +1212,7 @@ yystate(38, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(38, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1222,7 +1228,7 @@ yystate(37, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(37, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1240,7 +1246,7 @@ yystate(35, [68|Ics], Line, Tlen, _, _) ->
     yystate(27, Ics, Line, Tlen+1, 10, Tlen);
 yystate(35, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 67 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1256,7 +1262,7 @@ yystate(34, [83|Ics], Line, Tlen, _, _) ->
     yystate(26, Ics, Line, Tlen+1, 10, Tlen);
 yystate(34, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1272,7 +1278,7 @@ yystate(33, [81|Ics], Line, Tlen, _, _) ->
     yystate(41, Ics, Line, Tlen+1, 10, Tlen);
 yystate(33, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 80 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1286,7 +1292,7 @@ yystate(32, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(32, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1300,7 +1306,7 @@ yystate(31, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(31, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1316,7 +1322,7 @@ yystate(30, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(30, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1332,7 +1338,7 @@ yystate(29, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(29, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1346,7 +1352,7 @@ yystate(27, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 1, Tlen);
 yystate(27, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 1, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 1, Tlen);
 yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 1, Tlen);
@@ -1360,7 +1366,7 @@ yystate(26, [79|Ics], Line, Tlen, _, _) ->
     yystate(18, Ics, Line, Tlen+1, 10, Tlen);
 yystate(26, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 78 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1376,7 +1382,7 @@ yystate(25, [69|Ics], Line, Tlen, _, _) ->
     yystate(33, Ics, Line, Tlen+1, 10, Tlen);
 yystate(25, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1392,7 +1398,7 @@ yystate(24, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(24, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1408,7 +1414,7 @@ yystate(23, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(23, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1428,7 +1434,7 @@ yystate(22, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(22, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1442,7 +1448,7 @@ yystate(21, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(21, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1468,7 +1474,7 @@ yystate(18, [78|Ics], Line, Tlen, _, _) ->
     yystate(40, Ics, Line, Tlen+1, 10, Tlen);
 yystate(18, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1484,7 +1490,7 @@ yystate(17, [82|Ics], Line, Tlen, _, _) ->
     yystate(25, Ics, Line, Tlen+1, 10, Tlen);
 yystate(17, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1500,7 +1506,7 @@ yystate(16, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(16, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1514,7 +1520,7 @@ yystate(15, [95|Ics], Line, Tlen, _, _) ->
     yystate(23, Ics, Line, Tlen+1, 5, Tlen);
 yystate(15, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 5, Tlen);
@@ -1528,7 +1534,7 @@ yystate(14, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(14, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1544,7 +1550,7 @@ yystate(13, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(13, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1568,7 +1574,7 @@ yystate(10, [85|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 10, Tlen);
 yystate(10, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1582,7 +1588,7 @@ yystate(9, [95|Ics], Line, Tlen, _, _) ->
     yystate(17, Ics, Line, Tlen+1, 10, Tlen);
 yystate(9, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1596,7 +1602,7 @@ yystate(8, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(8, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1612,7 +1618,7 @@ yystate(7, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(7, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1628,7 +1634,7 @@ yystate(6, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(6, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1642,7 +1648,7 @@ yystate(5, [76|Ics], Line, Tlen, _, _) ->
     yystate(9, Ics, Line, Tlen+1, 10, Tlen);
 yystate(5, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1666,7 +1672,7 @@ yystate(2, [76|Ics], Line, Tlen, _, _) ->
     yystate(5, Ics, Line, Tlen+1, 10, Tlen);
 yystate(2, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1682,7 +1688,7 @@ yystate(1, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(1, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1698,7 +1704,7 @@ yystate(0, [95|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(0, [45|Ics], Line, Tlen, _, _) ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 49, C =< 57 ->
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
     yystate(32, Ics, Line, Tlen+1, 10, Tlen);
@@ -1782,7 +1788,7 @@ yyaction_5(TokenChars, TokenLine) ->
 -compile({inline,yyaction_6/2}).
 -file("src/when_lexer.xrl", 28).
 yyaction_6(TokenChars, TokenLine) ->
-     { token, { boolean, TokenLine, to_lowercase_binary (TokenChars) } } .
+     { token, { boolean, TokenLine, to_boolean (TokenChars) } } .
 
 -compile({inline,yyaction_7/2}).
 -file("src/when_lexer.xrl", 29).
@@ -1802,7 +1808,7 @@ yyaction_9(TokenChars, TokenLine) ->
 -compile({inline,yyaction_10/2}).
 -file("src/when_lexer.xrl", 32).
 yyaction_10(TokenChars, TokenLine) ->
-     { token, { identifier, TokenLine, to_lowercase_binary (TokenChars) } } .
+     { token, { identifier, TokenLine, to_atom (TokenChars) } } .
 
 -compile({inline,yyaction_11/0}).
 -file("src/when_lexer.xrl", 33).

--- a/src/when_lexer.xrl
+++ b/src/when_lexer.xrl
@@ -3,8 +3,21 @@ Definitions.
 KEYWORD = branch|BRANCH|tag|TAG|pull_request|PULL_REQUEST|result|RESULT|result_reason|RESULT_REASON
 OPERATOR = =|!=|=~|!~
 BOOL_OPERATOR = and|AND|or|OR
-BOOLEAN = true|TRUE|false|FALSE
 WHITESPACE = [\s\t\n\r]
+BOOLEAN = true|TRUE|false|FALSE
+STRING = '[^\']+'
+
+Digit = [0-9]
+NonZeroDigit = [1-9]
+NegativeSign = [\-]
+Sign = [\+\-]
+FractionalPart = \.{Digit}+
+IntegerPart = {NegativeSign}?0|{NegativeSign}?{NonZeroDigit}{Digit}*
+
+INTEGER = {IntegerPart}
+FLOAT = {IntegerPart}{FractionalPart}
+
+IDENTIFIER = [a-zA-Z][a-zA-Z0-9_\-]*
 
 Rules.
 
@@ -12,9 +25,13 @@ Rules.
 {BOOL_OPERATOR} : {token, {bool_operator,  TokenLine, to_lowercase_binary(TokenChars)}}.
 \(              : {token, {'(',  TokenLine}}.
 \)              : {token, {')',  TokenLine}}.
+,               : {token, {',',  TokenLine}}.
 {KEYWORD}       : {token, {keyword,  TokenLine, to_lowercase_binary(TokenChars)}}.
 {BOOLEAN}       : {token, {boolean,  TokenLine, to_lowercase_binary(TokenChars)}}.
-'[^\']+'        : {token, {string, TokenLine, extract_string(TokenChars)}}.
+{STRING}        : {token, {string, TokenLine, extract_string(TokenChars)}}.
+{INTEGER}       : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
+{FLOAT}         : {token, {float, TokenLine, list_to_float(TokenChars)}}.
+{IDENTIFIER}    : {token, {identifier, TokenLine, to_atom(TokenChars)}}.
 {WHITESPACE}+   : skip_token.
 
 Erlang code.
@@ -24,3 +41,9 @@ extract_string(Chars) ->
 
 to_lowercase_binary(Chars) ->
     string:lowercase(list_to_binary(Chars)).
+
+to_boolean(Chars) ->
+    erlang:binary_to_existing_atom(string:lowercase(list_to_binary(Chars)), utf8).
+
+to_atom(Chars) ->
+    erlang:binary_to_atom(list_to_binary(Chars), utf8).

--- a/src/when_lexer.xrl
+++ b/src/when_lexer.xrl
@@ -27,7 +27,7 @@ Rules.
 \)              : {token, {')',  TokenLine}}.
 ,               : {token, {',',  TokenLine}}.
 {KEYWORD}       : {token, {keyword,  TokenLine, to_lowercase_binary(TokenChars)}}.
-{BOOLEAN}       : {token, {boolean,  TokenLine, to_lowercase_binary(TokenChars)}}.
+{BOOLEAN}       : {token, {boolean,  TokenLine, to_boolean(TokenChars)}}.
 {STRING}        : {token, {string, TokenLine, extract_string(TokenChars)}}.
 {INTEGER}       : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
 {FLOAT}         : {token, {float, TokenLine, list_to_float(TokenChars)}}.

--- a/src/when_parser.erl
+++ b/src/when_parser.erl
@@ -1,6 +1,6 @@
 -module(when_parser).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("src/when_parser.yrl", 16).
+-file("src/when_parser.yrl", 27).
 
 extract_token({_Token, _Line, Value}) -> Value.
 
@@ -186,10 +186,10 @@ yeccpars2(0=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_1(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(2=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_2(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(3=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_0(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(3=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_3(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(4=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_4(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_0(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(5=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_5(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(6=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -202,85 +202,112 @@ yeccpars2(9=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(10=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_10(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(11=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_11(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(11=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_11(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(12=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_12(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(13=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_13(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(14=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_14(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(15=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_15(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_16(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_0(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(14=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_14(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_21(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_0(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(25=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_25(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(26=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_0(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(27=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_27(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
 -dialyzer({nowarn_function, yeccpars2_0/7}).
 yeccpars2_0(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 3, Ss, Stack, T, Ts, Tzr);
-yeccpars2_0(S, boolean, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 4, Ss, Stack, T, Ts, Tzr);
-yeccpars2_0(S, keyword, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_0(S, boolean, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 5, Ss, Stack, T, Ts, Tzr);
-yeccpars2_0(S, string, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_0(S, float, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 6, Ss, Stack, T, Ts, Tzr);
+yeccpars2_0(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 7, Ss, Stack, T, Ts, Tzr);
+yeccpars2_0(S, integer, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 8, Ss, Stack, T, Ts, Tzr);
+yeccpars2_0(S, keyword, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 9, Ss, Stack, T, Ts, Tzr);
+yeccpars2_0(S, string, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 10, Ss, Stack, T, Ts, Tzr);
 yeccpars2_0(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_expression(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_2/7}).
-yeccpars2_2(_S, '$end', _Ss, Stack, _T, _Ts, _Tzr) ->
+yeccpars2_2(S, operator, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_2(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccgoto_term(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, yeccpars2_3/7}).
+yeccpars2_3(_S, '$end', _Ss, Stack, _T, _Ts, _Tzr) ->
  {ok, hd(Stack)};
-yeccpars2_2(S, bool_operator, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
-yeccpars2_2(_, _, _, _, T, _, _) ->
+yeccpars2_3(S, bool_operator, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 24, Ss, Stack, T, Ts, Tzr);
+yeccpars2_3(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_3: see yeccpars2_0
+%% yeccpars2_4: see yeccpars2_0
 
-yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_4_(Stack),
+yeccpars2_5(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_5_(Stack),
  yeccgoto_term(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_5/7}).
-yeccpars2_5(S, operator, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 9, Ss, Stack, T, Ts, Tzr);
-yeccpars2_5(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_6(S, operator, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 7, Ss, Stack, T, Ts, Tzr);
 yeccpars2_6(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_6_(Stack),
  yeccgoto_term(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_7/7}).
-yeccpars2_7(S, keyword, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 8, Ss, Stack, T, Ts, Tzr);
+yeccpars2_7(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
 yeccpars2_7(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
  NewStack = yeccpars2_8_(Stack),
- yeccgoto_term(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_term(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_9/7}).
-yeccpars2_9(S, string, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 10, Ss, Stack, T, Ts, Tzr);
+yeccpars2_9(S, operator, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
 yeccpars2_9(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
+yeccpars2_10(S, operator, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 11, Ss, Stack, T, Ts, Tzr);
 yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
  NewStack = yeccpars2_10_(Stack),
- yeccgoto_term(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_term(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_11/7}).
-yeccpars2_11(S, ')', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_11(S, keyword, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 12, Ss, Stack, T, Ts, Tzr);
-yeccpars2_11(S, bool_operator, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -289,37 +316,128 @@ yeccpars2_12(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_12_(Stack),
  yeccgoto_term(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_13: see yeccpars2_0
+-dialyzer({nowarn_function, yeccpars2_13/7}).
+yeccpars2_13(S, string, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 14, Ss, Stack, T, Ts, Tzr);
+yeccpars2_13(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_14_(Stack),
+ yeccgoto_term(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_15(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 18, Ss, Stack, T, Ts, Tzr);
+yeccpars2_15(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_0(S, Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_16(S, ',', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
+yeccpars2_16(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_16_(Stack),
+ yeccgoto_params(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, yeccpars2_17/7}).
+yeccpars2_17(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
+yeccpars2_17(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_18_(Stack),
+ 'yeccgoto_\'fun\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_19_(Stack),
+ 'yeccgoto_\'fun\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_20: see yeccpars2_0
+
+yeccpars2_21(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_21_(Stack),
+ yeccgoto_params(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, yeccpars2_22/7}).
+yeccpars2_22(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 23, Ss, Stack, T, Ts, Tzr);
+yeccpars2_22(S, bool_operator, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 24, Ss, Stack, T, Ts, Tzr);
+yeccpars2_22(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_23(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_23_(Stack),
+ yeccgoto_term(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_24: see yeccpars2_0
+
+yeccpars2_25(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_25_(Stack),
  yeccgoto_expression(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_26: see yeccpars2_0
+
+yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_27_(Stack),
+ yeccgoto_term(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_expression/7}).
 yeccgoto_expression(0, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_expression(4, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_22(22, Cat, Ss, Stack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, 'yeccgoto_\'fun\''/7}).
+'yeccgoto_\'fun\''(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_2(2, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_expression(3, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_11(11, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'fun\''(4, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_2(2, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'fun\''(15, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_2(2, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'fun\''(20, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_2(2, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'fun\''(24, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_2(2, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'fun\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_2(2, Cat, Ss, Stack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, yeccgoto_params/7}).
+yeccgoto_params(15, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_17(17, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_params(20=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_21(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_term/7}).
 yeccgoto_term(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_term(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccgoto_term(4=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_term(13=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_term(15, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_16(16, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_term(20, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_16(16, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_term(24=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_25(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_term(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
--compile({inline,yeccpars2_4_/1}).
--file("src/when_parser.yrl", 10).
-yeccpars2_4_(__Stack0) ->
+-compile({inline,yeccpars2_5_/1}).
+-file("src/when_parser.yrl", 11).
+yeccpars2_5_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    extract_token ( __1 )
   end | __Stack].
 
 -compile({inline,yeccpars2_6_/1}).
--file("src/when_parser.yrl", 9).
+-file("src/when_parser.yrl", 13).
 yeccpars2_6_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -327,36 +445,92 @@ yeccpars2_6_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("src/when_parser.yrl", 8).
+-file("src/when_parser.yrl", 12).
 yeccpars2_8_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
+ [__1 | __Stack] = __Stack0,
  [begin
-   { extract_token ( __2 ) , extract_token ( __3 ) , extract_token ( __1 ) }
+   extract_token ( __1 )
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("src/when_parser.yrl", 7).
+-file("src/when_parser.yrl", 10).
 yeccpars2_10_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
+ [__1 | __Stack] = __Stack0,
  [begin
-   { extract_token ( __2 ) , extract_token ( __1 ) , extract_token ( __3 ) }
+   extract_token ( __1 )
   end | __Stack].
 
 -compile({inline,yeccpars2_12_/1}).
--file("src/when_parser.yrl", 6).
+-file("src/when_parser.yrl", 8).
 yeccpars2_12_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   { extract_token ( __2 ) , extract_token ( __1 ) , { keyword , extract_token ( __3 ) } }
+  end | __Stack].
+
+-compile({inline,yeccpars2_14_/1}).
+-file("src/when_parser.yrl", 7).
+yeccpars2_14_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   { extract_token ( __2 ) , { keyword , extract_token ( __1 ) } , extract_token ( __3 ) }
+  end | __Stack].
+
+-compile({inline,yeccpars2_16_/1}).
+-file("src/when_parser.yrl", 20).
+yeccpars2_16_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_18_/1}).
+-file("src/when_parser.yrl", 18).
+yeccpars2_18_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   { 'fun' , extract_token ( __1 ) , [ ] }
+  end | __Stack].
+
+-compile({inline,yeccpars2_19_/1}).
+-file("src/when_parser.yrl", 19).
+yeccpars2_19_(__Stack0) ->
+ [__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   { 'fun' , extract_token ( __1 ) , __3 }
+  end | __Stack].
+
+-compile({inline,yeccpars2_21_/1}).
+-file("src/when_parser.yrl", 21).
+yeccpars2_21_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 ] ++ __3
+  end | __Stack].
+
+-compile({inline,yeccpars2_23_/1}).
+-file("src/when_parser.yrl", 6).
+yeccpars2_23_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_14_/1}).
+-compile({inline,yeccpars2_25_/1}).
 -file("src/when_parser.yrl", 3).
-yeccpars2_14_(__Stack0) ->
+yeccpars2_25_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   { extract_token ( __2 ) , __1 , __3 }
+  end | __Stack].
+
+-compile({inline,yeccpars2_27_/1}).
+-file("src/when_parser.yrl", 15).
+yeccpars2_27_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    { extract_token ( __2 ) , __1 , __3 }
   end | __Stack].
 
 
--file("src/when_parser.yrl", 19).
+-file("src/when_parser.yrl", 30).

--- a/src/when_parser.yrl
+++ b/src/when_parser.yrl
@@ -7,11 +7,12 @@ Rootsymbol expression.
 expression -> expression bool_operator term : {extract_token('$2'), '$1', '$3'}.
 expression -> term : '$1'.
 
-term -> '(' expression ')'      : '$2'.
-term -> keyword operator string : {extract_token('$2'), extract_token('$1'), extract_token('$3')}.
-term -> string operator keyword : {extract_token('$2'), extract_token('$3'), extract_token('$1')}.
-term -> string                  : extract_token('$1').
-term -> boolean                 : extract_token('$1').
+term -> '(' expression ')'        : '$2'.
+term -> keyword operator string   : {extract_token('$2'), {'keyword', extract_token('$1')}, extract_token('$3')}.
+term -> string operator keyword   : {extract_token('$2'), extract_token('$1'), {'keyword', extract_token('$3')}}.
+
+term -> string                    : extract_token('$1').
+term -> boolean                   : extract_token('$1').
 
 Erlang code.
 

--- a/src/when_parser.yrl
+++ b/src/when_parser.yrl
@@ -1,6 +1,6 @@
-Nonterminals expression term.
+Nonterminals expression term params fun.
 
-Terminals operator bool_operator '(' ')' keyword string boolean.
+Terminals operator bool_operator '(' ')' keyword string boolean integer float identifier ','.
 
 Rootsymbol expression.
 
@@ -13,6 +13,16 @@ term -> string operator keyword   : {extract_token('$2'), extract_token('$1'), {
 
 term -> string                    : extract_token('$1').
 term -> boolean                   : extract_token('$1').
+term -> integer                   : extract_token('$1').
+term -> float                     : extract_token('$1').
+term -> fun                       : '$1'.
+term -> fun operator term         : {extract_token('$2'), '$1', '$3'}.
+
+
+fun -> identifier '(' ')'        : {'fun', extract_token('$1'), []}.
+fun -> identifier '(' params ')' : {'fun', extract_token('$1'), '$3'}.
+params -> term                   : ['$1'].
+params -> term ',' params        : ['$1'] ++ '$3'.
 
 Erlang code.
 

--- a/test/when/interpreter_test.exs
+++ b/test/when/interpreter_test.exs
@@ -4,18 +4,18 @@ defmodule When.Interpreter.Test do
   alias When.Interpreter
 
   @test_ast_examples [
-    "true",
-    "false",
-    {"and", "false", {"!=", "tag", "v1.*"}},
-    {"and", {"=", "branch", "master"}, {"=~", "tag", "v1.*"}},
-    {"or", {"and", {"=", "branch", "master"}, {"=~", "tag", "v1.*"}},
-           {"!=", "result", "passed"}},
-    {"and", {"=", "branch", "master"},
-            {"or", {"=~", "tag", "v1.*"}, {"!=", "result_reason", "stopped"}}},
-    {"or", {"and", {"=", "branch", "master"}, {"!=", "result", "failed"}},
-           {"and", {"and", {"=~", "tag", "v1.*"}, {"=", "result", "passed"}},
-                   {"!=", "result_reason", "skipped"}}},
-    {"and", {"=~", "pull_request", ".*"}, {"=", "result", "passed"}}
+    true,
+    false,
+    {"and", false, {"!=", {:keyword, "tag"}, "v1.*"}},
+    {"and", {"=", {:keyword, "branch"}, "master"}, {"=~", {:keyword, "tag"}, "v1.*"}},
+    {"or", {"and", {"=", {:keyword, "branch"}, "master"}, {"=~", {:keyword, "tag"}, "v1.*"}},
+           {"!=", {:keyword, "result"}, "passed"}},
+    {"and", {"=", {:keyword, "branch"}, "master"},
+            {"or", {"=~", {:keyword, "tag"}, "v1.*"}, {"!=", {:keyword, "result_reason"}, "stopped"}}},
+    {"or", {"and", {"=", {:keyword, "branch"}, "master"}, {"!=", {:keyword, "result"}, "failed"}},
+           {"and", {"and", {"=~", {:keyword, "tag"}, "v1.*"}, {"=", {:keyword, "result"}, "passed"}},
+                   {"!=", {:keyword, "result_reason"}, "skipped"}}},
+    {"and", {"=~", {:keyword, "pull_request"}, ".*"}, {"=", {:keyword, "result"}, "passed"}},
   ]
 
   @test_params_examples [
@@ -62,10 +62,10 @@ defmodule When.Interpreter.Test do
 
   test "if value of keyword parameter isn't given all expression with it will return internal error" do
     [
-     {"=", "branch", "master"}, {"!=", "branch", "master"},
-     {"=~", "branch", "master"}, {"!~", "branch", "master"},
-     {"and", {"=", "branch", "master"}, "false"}, {"and", "false", {"=", "branch", "master"}},
-     {"or", {"=", "branch", "master"}, "false"}, {"or", "false", {"=", "branch", "master"}},
+     {"=", {:keyword, "branch"}, "master"}, {"!=", {:keyword, "branch"}, "master"},
+     {"=~", {:keyword, "branch"}, "master"}, {"!~", {:keyword, "branch"}, "master"},
+     {"and", {"=", {:keyword, "branch"}, "master"}, "false"}, {"and", "false", {"=", {:keyword, "branch"}, "master"}},
+     {"or", {"=", {:keyword, "branch"}, "master"}, "false"}, {"or", "false", {"=", {:keyword, "branch"}, "master"}},
     ]
     |> Enum.map(fn ast ->
       assert {:error, message} = Interpreter.evaluate(ast, %{})

--- a/test/when/lexer_test.exs
+++ b/test/when/lexer_test.exs
@@ -12,7 +12,8 @@ defmodule When.Lexer.Test do
     "(branch = 'master' and tag =~ 'v1.*') or result != 'passed'",
     "(branch = 'master' AND tag =~ 'v1.*') OR result_reason != 'stopped'",
     "((BRANCH !~ 'master') and tag =~ 'v1.*') OR (result_reason != 'stopped')",
-    "(pull_request =~ '.*' and result = 'passed') or PULL_REQUEST !~ '.*'"
+    "(pull_request =~ '.*' and result = 'passed') or PULL_REQUEST !~ '.*'",
+    "some_fun('abc', 123, 45.67, true) or false"
   ]
 
   @expected_example_results [
@@ -52,6 +53,11 @@ defmodule When.Lexer.Test do
       {:bool_operator, 1, "and"}, {:keyword, 1, "result"}, {:operator, 1, "="},
       {:string, 1, "passed"}, {:')',  1}, {:bool_operator, 1, "or"},
       {:keyword, 1, "pull_request"}, {:operator, 1, "!~"}, {:string, 1, ".*"}
+    ],
+    [
+      {:identifier, 1, :some_fun}, {:'(',  1}, {:string, 1, "abc"}, {:',',  1},
+      {:integer, 1, 123}, {:',',  1}, {:float, 1, 45.67}, {:',',  1},
+      {:boolean, 1, "true"}, {:')',  1}, {:bool_operator, 1, "or"}, {:boolean, 1, "false"}
     ]
   ]
 
@@ -66,23 +72,21 @@ defmodule When.Lexer.Test do
   end
 
   @invald_strings [
-    "bran",
     "branch ! = 'bad operator'",
-    "branch = unquoted-string",
-    "branch = unquoted string with whitespace",
-    "Branch =~ 'not-same-case-of-letters'",
     "[branch = 'unsupported-brackets'] and true",
-    "# branch = 'unsupported-characters'"
+    "# branch = 'unsupported-characters'",
+    "_identifier_needs_to_start_with_lettter(123)",
+    "cant_contain_&^('identifier only accepts alfa-numerics, uderscores and dashes')",
+    "fun(123.0) and invalid_number(123.456.2323)"
   ]
 
   @error_messages [
-    "Illegal characters: 'bran'.",
     "Illegal characters: '! '.",
-    "Illegal characters: 'u'.",
-    "Illegal characters: 'u'.",
-    "Illegal characters: 'Br'.",
     "Illegal characters: '['.",
     "Illegal characters: '#'.",
+    "Illegal characters: '_'.",
+    "Illegal characters: '&'.",
+    "Illegal characters: '.'."
   ]
 
   test "lexer returns error when invalid string is given" do

--- a/test/when/lexer_test.exs
+++ b/test/when/lexer_test.exs
@@ -17,11 +17,11 @@ defmodule When.Lexer.Test do
   ]
 
   @expected_example_results [
-    [{:boolean, 1, "true"}],
+    [{:boolean, 1, true}],
     [{:string, 1, "true"}],
     [{:'(',  1}, {:string, 1, "false"}, {:')',  1}],
     [
-     {:'(',  1}, {:boolean, 1, "false"}, {:')',  1}, {:bool_operator, 1, "and"},
+     {:'(',  1}, {:boolean, 1, false}, {:')',  1}, {:bool_operator, 1, "and"},
      {:keyword, 1, "tag"}, {:operator, 1, "!="}, {:string, 1, "v1.*"}
     ],
     [
@@ -57,7 +57,7 @@ defmodule When.Lexer.Test do
     [
       {:identifier, 1, :some_fun}, {:'(',  1}, {:string, 1, "abc"}, {:',',  1},
       {:integer, 1, 123}, {:',',  1}, {:float, 1, 45.67}, {:',',  1},
-      {:boolean, 1, "true"}, {:')',  1}, {:bool_operator, 1, "or"}, {:boolean, 1, "false"}
+      {:boolean, 1, true}, {:')',  1}, {:bool_operator, 1, "or"}, {:boolean, 1, false}
     ]
   ]
 

--- a/test/when/parser_test.exs
+++ b/test/when/parser_test.exs
@@ -17,11 +17,11 @@ defmodule When.Parser.Test do
   ]
 
   @expected_tokens [
-    [{:boolean, 1, "true"}],
+    [{:boolean, 1, true}],
     [{:string, 1, "true"}],
     [{:'(',  1}, {:string, 1, "false"}, {:')',  1}],
     [
-     {:'(',  1}, {:boolean, 1, "false"}, {:')',  1}, {:bool_operator, 1, "and"},
+     {:'(',  1}, {:boolean, 1, false}, {:')',  1}, {:bool_operator, 1, "and"},
      {:keyword, 1, "tag"}, {:operator, 1, "!="}, {:string, 1, "v1.*"}
     ],
     [
@@ -55,24 +55,51 @@ defmodule When.Parser.Test do
       {:bool_operator, 1, "and"}, {:keyword, 1, "result"}, {:operator, 1, "="},
       {:string, 1, "passed"}, {:')',  1}, {:bool_operator, 1, "or"},
       {:keyword, 1, "pull_request"}, {:operator, 1, "!~"}, {:string, 1, ".*"}
+    ],
+    [
+      {:identifier, 1, :some_fun}, {:'(',  1}, {:integer, 1, 123}, {:')',  1},
+      {:bool_operator, 1, "and"}, {:'(',  1}, {:identifier, 1, :other_fun},
+      {:'(',  1}, {:string, 1, "abc"}, {:',',  1}, {:float, 1, 4.56}, {:',',  1},
+      {:boolean, 1, false}, {:')',  1}, {:operator, 1, "="},
+      {:integer, 1, 7}, {:')',  1}
+    ],
+    [
+      {:identifier, 1, :FUNCTION}, {:'(',  1}, {:')',  1}
+    ],
+    [
+      {:'(',  1}, {:identifier, 1, :some_fun}, {:'(',  1}, {:')',  1},
+      {:bool_operator, 1, "or"}, {:'(',  1}, {:keyword, 1, "branch"},
+      {:operator, 1, "="}, {:string, 1, "master"}, {:bool_operator, 1, "and"},
+      {:keyword, 1, "tag"}, {:operator, 1, "=~"}, {:string, 1, "v1.*"}, {:')',  1},
+      {:')',  1}, {:bool_operator, 1, "and"}, {:boolean, 1, true}
     ]
   ]
 
   @expected_parse_results [
-    "true",
+    true,
     "true",
     "false",
-    {"and", "false", {"!=", "tag", "v1.*"}},
-    {"and", {"=", "branch", "master"}, {"=~", "tag", "v1.*"}},
-    {"or", {"and", {"=", "branch", "master"}, {"=~", "tag", "v1.*"}},
-           {"!=", "result", "passed"}},
-    {"and", {"=", "branch", "master"},
-            {"or", {"=~", "tag", "v1.*"}, {"!=", "result_reason", "stopped"}}},
-    {"or", {"and", {"=", "branch", "master"}, {"!=", "result", "failed"}},
-           {"and", {"and", {"=~", "tag", "v1.*"}, {"=", "result", "passed"}},
-                   {"!=", "result_reason", "skipped"}}},
-   {"or", {"and", {"=~", "pull_request", ".*"}, {"=", "result", "passed"}},
-          {"!~", "pull_request", ".*"}}
+    {"and", false, {"!=", {:keyword, "tag"}, "v1.*"}},
+
+    {"and", {"=", {:keyword, "branch"}, "master"}, {"=~", {:keyword, "tag"}, "v1.*"}},
+
+    {"or", {"and", {"=", {:keyword, "branch"}, "master"},
+                   {"=~", {:keyword, "tag"}, "v1.*"}},
+           {"!=", {:keyword, "result"}, "passed"}},
+
+    {"and", {"=", {:keyword, "branch"}, "master"},
+            {"or", {"=~", {:keyword, "tag"}, "v1.*"},
+                   {"!=", {:keyword, "result_reason"}, "stopped"}}},
+
+    {"or", {"and", {"=", {:keyword, "branch"}, "master"},
+                   {"!=", {:keyword, "result"}, "failed"}},
+           {"and", {"and", {"=~", {:keyword, "tag"}, "v1.*"},
+                           {"=", {:keyword, "result"}, "passed"}},
+                   {"!=", {:keyword, "result_reason"}, "skipped"}}},
+
+   {"or", {"and", {"=~", {:keyword, "pull_request"}, ".*"},
+                  {"=", {:keyword, "result"}, "passed"}},
+          {"!~", {:keyword, "pull_request"}, ".*"}},
   ]
 
   test "test parser behavior for various token examples" do
@@ -107,12 +134,12 @@ defmodule When.Parser.Test do
 
   @invalid_tokens [
     [
-     {:'(',  1}, {:boolean, 1, "true"}, {:bool_operator, 1, "and"},
-     {:boolean, 1, "false"}, {:')',  1}, {:operator, 1, "="}, {:string, 1, "master"}
+     {:'(',  1}, {:boolean, 1, true}, {:bool_operator, 1, "and"},
+     {:boolean, 1, false}, {:')',  1}, {:operator, 1, "="}, {:string, 1, "master"}
     ],
     [
-     {:string, 1, "master"}, {:operator, 1, "!="}, {:'(',  1}, {:boolean, 1, "true"},
-     {:bool_operator, 1, "and"}, {:boolean, 1, "false"}, {:')',  1}
+     {:string, 1, "master"}, {:operator, 1, "!="}, {:'(',  1}, {:boolean, 1, true},
+     {:bool_operator, 1, "and"}, {:boolean, 1, false}, {:')',  1}
     ],
     [
      {:bool_operator, 1, "and"}, {:keyword, 1, "branch"}, {:operator, 1, "!="},
@@ -123,7 +150,7 @@ defmodule When.Parser.Test do
     [{:string, 1, "true"}, {:bool_operator, 1, "or"}],
     [{:operator, 1, "="}],
     [{:'(',  1}, {:keyword, 1, "branch"}, {:operator, 1, "="}, {:string, 1, "master"}],
-    [{:boolean, 1, "true"}, {:bool_operator, 1, "or"}, {:boolean, 1, "false"}, {:')',  1}],
+    [{:boolean, 1, true}, {:bool_operator, 1, "or"}, {:boolean, 1, false}, {:')',  1}],
   ]
 
   @error_messages [

--- a/test/when/parser_test.exs
+++ b/test/when/parser_test.exs
@@ -13,7 +13,10 @@ defmodule When.Parser.Test do
     "branch = 'master' AND (tag =~ 'v1.*' OR result_reason != 'stopped')",
     "(branch = 'master' and result != 'failed') or
      (tag =~ 'v1.*' and result = 'passed' and result_reason != 'skipped')",
-    "(pull_request =~ '.*' and result = 'passed') or PULL_REQUEST !~ '.*'"
+    "(pull_request =~ '.*' and result = 'passed') or PULL_REQUEST !~ '.*'",
+    "some_fun(123) and (other_fun('abc', 4.56, false) = 7)",
+    "FUNCTION()",
+    "(some_fun() or (branch = 'master' and tag =~ 'v1.*')) AND true",
   ]
 
   @expected_tokens [
@@ -100,6 +103,16 @@ defmodule When.Parser.Test do
    {"or", {"and", {"=~", {:keyword, "pull_request"}, ".*"},
                   {"=", {:keyword, "result"}, "passed"}},
           {"!~", {:keyword, "pull_request"}, ".*"}},
+
+   {"and", {:fun, :some_fun, [123]},
+           {"=", {:fun, :other_fun, ["abc", 4.56, false]}, 7}},
+
+   {:fun, :FUNCTION, []},
+
+   {"and", {"or", {:fun, :some_fun, []},
+                  {"and", {"=", {:keyword, "branch"}, "master"},
+                          {"=~", {:keyword, "tag"}, "v1.*"}}},
+           true}
   ]
 
   test "test parser behavior for various token examples" do

--- a/test/when_test.exs
+++ b/test/when_test.exs
@@ -92,23 +92,21 @@ defmodule When.Test do
   end
 
   @invald_strings_lexer [
-    "bran",
     "branch ! = 'bad operator'",
-    "branch = unquoted-string",
-    "branch = unquoted string with whitespace",
-    "Branch =~ 'not-same-case-of-letters'",
     "[branch = 'unsupported-brackets'] and true",
-    "# branch = 'unsupported-characters'"
+    "# branch = 'unsupported-characters'",
+    "_identifier_needs_to_start_with_lettter(123)",
+    "cant_contain_&^('identifier only accepts alfa-numerics, uderscores and dashes')",
+    "fun(123.0) and invalid_number(123.456.2323)"
   ]
 
   @error_messages_lexer [
-    "Illegal characters: 'bran'.",
     "Illegal characters: '! '.",
-    "Illegal characters: 'u'.",
-    "Illegal characters: 'u'.",
-    "Illegal characters: 'Br'.",
     "Illegal characters: '['.",
     "Illegal characters: '#'.",
+    "Illegal characters: '_'.",
+    "Illegal characters: '&'.",
+    "Illegal characters: '.'."
   ]
 
   test "lexer returns error when invalid string is given" do


### PR DESCRIPTION
Adds support for function calls in string conditions. 

Functions can have fro 0 to n parameters where each parameter can be string, boolean, float or integer.

Support for lists and maps as the parameters will be added later.

The function should return `{:ok, result}` tuple, or `{:error, message}` one if there is an error.

If the function is used in a boolean expression and it returns the non-boolean results, it is interpreted as a boolean in the following way:
- all non-empty strings are considered as `true`
- all integers and floats larger than `0` are considered as `true`
- otherwise, the result is interpreted as `false`

The function implementations are tied to function calls via configuration in the config file.