### PR TITLE
[wip] Change in evaluator PoC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ console:
 	docker run --network=host $(CONTAINER_ENV_VARS) $(INTERACTIVE_SESSION) $(CMD)
 
 test:
-	$(MAKE) console USER=root MIX_ENV=test CMD="mix do local.hex --force, local.rebar --force, deps.get, test"
+	$(MAKE) console USER=root MIX_ENV=test CMD="mix do local.hex --force, local.rebar --force, deps.get, test $(FILE)"

--- a/lib/when.ex
+++ b/lib/when.ex
@@ -6,15 +6,90 @@ defmodule When do
   params map.
   """
 
-  alias  When.{Lexer, Parser, Interpreter}
+  alias When.{Lexer, Parser, Interpreter}
 
   def evaluate(string_expression, params, opts \\ []) do
     with {:ok, tokens} <- Lexer.tokenize(string_expression),
-         {:ok, ast}    <- Parser.parse(tokens),
-         result when is_boolean(result)
-                       <- Interpreter.evaluate(ast, params, opts)
-    do
+         {:ok, ast} <- Parser.parse(tokens),
+         result when is_boolean(result) <-
+           Interpreter.evaluate(ast, params, opts) do
       {:ok, result}
     end
+  end
+
+  #
+  #
+  # PoC change_in evaluator.
+  # Should be extracted from when parser into a dedicated system.
+  #
+  # The result of the evaluation is a list of evaluated change_in expressions.
+  #
+  # Example:
+  #
+  # [
+  #   %{pattern: "lib/**/*.ex", options: %{...}, result: false},
+  #   %{pattern: "test/lib/**/*.exs", options: %{...}, result: true}
+  # ]
+  #
+  #
+  def evaluate_change_in(input) do
+    {:ok, tokens} = Lexer.tokenize(input)
+    {:ok, ast} = Parser.parse(tokens)
+
+    result = evaluate_change_in_from_ast(ast)
+
+    IO.inspect(result)
+
+    result
+  end
+
+  def evaluate_change_in_from_ast({"and", left, right}) do
+    evaluate_change_in_from_ast(left) ++ evaluate_change_in_from_ast(right)
+  end
+
+  def evaluate_change_in_from_ast({"or", left, right}) do
+    evaluate_change_in_from_ast(left) ++ evaluate_change_in_from_ast(right)
+  end
+
+  def evaluate_change_in_from_ast({"=", left, right}) do
+    evaluate_change_in_from_ast(left) ++ evaluate_change_in_from_ast(right)
+  end
+
+  def evaluate_change_in_from_ast({"!=", left, right}) do
+    evaluate_change_in_from_ast(left) ++ evaluate_change_in_from_ast(right)
+  end
+
+  def evaluate_change_in_from_ast({"=~", left, right}) do
+    evaluate_change_in_from_ast(left) ++ evaluate_change_in_from_ast(right)
+  end
+
+  def evaluate_change_in_from_ast({"!~", left, right}) do
+    evaluate_change_in_from_ast(left) ++ evaluate_change_in_from_ast(right)
+  end
+
+  def evaluate_change_in_from_ast({:keyword, _}) do
+    []
+  end
+
+  def evaluate_change_in_from_ast(str) when is_binary(str) do
+    []
+  end
+
+  def evaluate_change_in_from_ast({:fun, :change_in, [pattern]}) do
+    evaluate_change_in_from_ast({:fun, :change_in, [pattern, %{}]})
+  end
+
+  def evaluate_change_in_from_ast({:fun, :change_in, [pattern, options]}) do
+    default_options = %{
+      default_branch: "master",
+      default_range: "somthing",
+      branch_range: "#somthing...12312312",
+      pipeline_file: "track",
+      on_tags: true
+    }
+
+    options = Map.merge(default_options, options)
+
+    [%{pattern: pattern, options: options, result: false}]
   end
 end

--- a/test/change_in_test.exs
+++ b/test/change_in_test.exs
@@ -1,0 +1,11 @@
+defmodule When.ChangeInTest do
+  use ExUnit.Case
+
+  test "evaluate change_in" do
+    When.evaluate_change_in("branch = 'test' and change_in('lib/**/*.ex', {})")
+
+    When.evaluate_change_in(
+      "branch = 'test' and change_in('test/lib/**/a.ex') or (pull_request = 'test' and change_in('lib/**/*.ex', {}))"
+    )
+  end
+end


### PR DESCRIPTION
I tried this approach: 

- Skip everything in the AST except change_in function calls.
- For every change_in generate a result.
- Return an array of evaluated change_in values.

While processing a pipeline, the full when evaluator would look up values from the above output.