### PR TITLE
Update elixir version to 1.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.12.3 as base
+FROM elixir:1.16.3 as base
 
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,12 @@ test: export MIX_ENV=test
 test: build
 	docker run --rm $(VOLUME_BIND) -v $(PWD)/out:/app/out $(CONTAINER_ENV_VARS)  $(IMAGE):$(IMAGE_TAG) mix test $(FILE) $(FLAGS)
 
+escript.build: export MIX_ENV=prod
 escript.build: build
 	docker run --rm --volume $(PWD):/app $(CONTAINER_ENV_VARS)  $(IMAGE):$(IMAGE_TAG) mix escript.build
+
+setup:
+	$(MAKE) cmd MIX_ENV=prod CMD="mix do deps.get, deps.compile"
 
 cmd: build
 	docker run --rm $(VOLUME_BIND) $(CONTAINER_ENV_VARS) $(IMAGE):$(IMAGE_TAG) $(CMD)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+import Config

--- a/lib/when/lexer.ex
+++ b/lib/when/lexer.ex
@@ -18,7 +18,7 @@ defmodule When.Lexer do
   defp pretty_error({:error, {line_no, :when_lexer, {:illegal, characters}}, _no}) do
     {:error,
      "Lexical error on line #{line_no}. - " <>
-       "Illegal characters: #{inspect(characters)}."}
+       "Illegal characters: '#{to_str(characters)}'."}
   end
 
   defp pretty_error({:error, error}) do
@@ -28,4 +28,16 @@ defmodule When.Lexer do
   defp pretty_error(error) do
     {:error, "Lexical error - Unrecongnized error: #{inspect(error)}"}
   end
+
+  defp to_str(value) when is_binary(value), do: value
+
+  defp to_str(value) when is_list(value) do
+    if List.ascii_printable?(value) do
+      List.to_string(value)
+    else
+      "#{inspect(value)}"
+    end
+  end
+
+  defp to_str(value), do: "#{inspect(value)}"
 end

--- a/lib/when/parser.ex
+++ b/lib/when/parser.ex
@@ -13,20 +13,20 @@ defmodule When.Parser do
   end
 
   defp pretty_error(
-         {:error, {line_no, :when_parser, ['syntax error before: ', [[_, _, operator, _, _]]]}}
+         {:error, {line_no, :when_parser, [~c"syntax error before: ", [[_, _, operator, _, _]]]}}
        ) do
     {:error,
      "Syntax error on line #{line_no}. - " <>
        "Invalid expression on the left of '#{rm_qoutes(operator)}' operator."}
   end
 
-  defp pretty_error({:error, {line_no, :when_parser, ['syntax error before: ', []]}}) do
+  defp pretty_error({:error, {line_no, :when_parser, [~c"syntax error before: ", []]}}) do
     {:error,
      "Syntax error on line #{line_no}. - " <>
        "Invalid or incomplete expression at the end of the line."}
   end
 
-  defp pretty_error({:error, {line_no, :when_parser, ['syntax error before: ', bracket]}}) do
+  defp pretty_error({:error, {line_no, :when_parser, [~c"syntax error before: ", bracket]}}) do
     {:error,
      "Syntax error on line #{line_no}. - " <>
        "Invalid expression on the left of '#{rm_qoutes(bracket)}'."}

--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,10 @@ defmodule When.MixProject do
     [
       app: :when,
       version: "0.1.0",
-      elixir: "~> 1.12",
+      elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      compilers: [:yecc, :leex] ++ Mix.compilers(),
       escript: escript()
     ]
   end

--- a/src/when_lexer.erl
+++ b/src/when_lexer.erl
@@ -1,4 +1,4 @@
--file("/usr/local/lib/erlang/lib/parsetools-2.1.6/include/leexinc.hrl", 0).
+-file("/usr/local/lib/erlang/lib/parsetools-2.5/include/leexinc.hrl", 0).
 %% The source of this file is part of leex distribution, as such it
 %% has the same Copyright as the other files in the leex
 %% distribution. The Copyright is defined in the accompanying file
@@ -29,266 +29,308 @@ to_boolean(Chars) ->
 to_atom(Chars) ->
     erlang:binary_to_atom(list_to_binary(Chars), utf8).
 
--file("/usr/local/lib/erlang/lib/parsetools-2.1.6/include/leexinc.hrl", 14).
+-file("/usr/local/lib/erlang/lib/parsetools-2.5/include/leexinc.hrl", 14).
 
 format_error({illegal,S}) -> ["illegal characters ",io_lib:write_string(S)];
 format_error({user,S}) -> S.
 
-string(String) -> string(String, 1).
+%% string(InChars) ->
+%% string(InChars, Loc) ->
+%% {ok,Tokens,EndLoc} | {error,ErrorInfo,EndLoc}.
+%% Loc is the starting location of the token, while EndLoc is the first not scanned
+%% location. Location is either Line or {Line,Column}, depending on the "error_location" option.
 
-string(String, Line) -> string(String, Line, String, []).
-
-%% string(InChars, Line, TokenChars, Tokens) ->
-%% {ok,Tokens,Line} | {error,ErrorInfo,Line}.
-%% Note the line number going into yystate, L0, is line of token
-%% start while line number returned is line of token end. We want line
-%% of token start.
-
-string([], L, [], Ts) ->                     % No partial tokens!
-    {ok,yyrev(Ts),L};
-string(Ics0, L0, Tcs, Ts) ->
-    case yystate(yystate(), Ics0, L0, 0, reject, 0) of
-        {A,Alen,Ics1,L1} ->                  % Accepting end state
-            string_cont(Ics1, L1, yyaction(A, Alen, Tcs, L0), Ts);
-        {A,Alen,Ics1,L1,_S1} ->              % Accepting transistion state
-            string_cont(Ics1, L1, yyaction(A, Alen, Tcs, L0), Ts);
-        {reject,_Alen,Tlen,_Ics1,L1,_S1} ->  % After a non-accepting state
-            {error,{L0,?MODULE,{illegal,yypre(Tcs, Tlen+1)}},L1};
-        {A,Alen,Tlen,_Ics1,L1,_S1} ->
-            Tcs1 = yysuf(Tcs, Alen),
-            L2 = adjust_line(Tlen, Alen, Tcs1, L1),
-            string_cont(Tcs1, L2, yyaction(A, Alen, Tcs, L0), Ts)
+string(Ics) -> 
+    string(Ics,1).
+string(Ics,L0) -> 
+    string(Ics, L0, 1, Ics, []).
+string(Ics, L0, C0, Tcs, Ts) -> 
+    case do_string(Ics, L0, C0, Tcs, Ts) of
+        {ok, T, {L,_}} -> {ok, T, L};
+        {error, {{EL,_},M,D}, {L,_}} ->
+            EI = {EL,M,D},
+            {error, EI, L}
     end.
 
-%% string_cont(RestChars, Line, Token, Tokens)
+do_string([], L, C, [], Ts) ->                     % No partial tokens!
+    {ok,yyrev(Ts),{L,C}};
+do_string(Ics0, L0, C0, Tcs, Ts) ->
+    case yystate(yystate(), Ics0, L0, C0, 0, reject, 0) of
+        {A,Alen,Ics1,L1,_C1} ->                  % Accepting end state
+            C2 = adjust_col(Tcs, Alen, C0),
+            string_cont(Ics1, L1, C2, yyaction(A, Alen, Tcs, L0, C0), Ts);
+        {A,Alen,Ics1,L1,_C1,_S1} ->              % Accepting transition state
+            C2 = adjust_col(Tcs, Alen, C0),
+            string_cont(Ics1, L1, C2, yyaction(A, Alen, Tcs, L0, C0), Ts);
+        {reject,_Alen,Tlen,_Ics1,_L1,_C1,_S1} ->  % After a non-accepting state
+            {error,{{L0, C0} ,?MODULE,{illegal,yypre(Tcs, Tlen+1)}},{L0, C0}};
+        {A,Alen,Tlen,_Ics1,L1, C1,_S1}->
+            Tcs1 = yysuf(Tcs, Alen),
+            L2 = adjust_line(Tlen, Alen, Tcs1, L1),
+            C2 = adjust_col(Tcs, Alen, C1),
+            string_cont(Tcs1, L2, C2, yyaction(A, Alen, Tcs, L0,C0), Ts)
+    end.
+
+%% string_cont(RestChars, Line, Col, Token, Tokens)
 %% Test for and remove the end token wrapper. Push back characters
 %% are prepended to RestChars.
 
--dialyzer({nowarn_function, string_cont/4}).
+-dialyzer({nowarn_function, string_cont/5}).
 
-string_cont(Rest, Line, {token,T}, Ts) ->
-    string(Rest, Line, Rest, [T|Ts]);
-string_cont(Rest, Line, {token,T,Push}, Ts) ->
+string_cont(Rest, Line, Col, {token,T}, Ts) ->
+    do_string(Rest, Line, Col, Rest, [T|Ts]);
+string_cont(Rest, Line, Col, {token,T,Push}, Ts) ->
     NewRest = Push ++ Rest,
-    string(NewRest, Line, NewRest, [T|Ts]);
-string_cont(Rest, Line, {end_token,T}, Ts) ->
-    string(Rest, Line, Rest, [T|Ts]);
-string_cont(Rest, Line, {end_token,T,Push}, Ts) ->
+    do_string(NewRest, Line, Col, NewRest, [T|Ts]);
+string_cont(Rest, Line, Col, {end_token,T}, Ts) ->
+    do_string(Rest, Line, Col, Rest, [T|Ts]);
+string_cont(Rest, Line, Col, {end_token,T,Push}, Ts) ->
     NewRest = Push ++ Rest,
-    string(NewRest, Line, NewRest, [T|Ts]);
-string_cont(Rest, Line, skip_token, Ts) ->
-    string(Rest, Line, Rest, Ts);
-string_cont(Rest, Line, {skip_token,Push}, Ts) ->
+    do_string(NewRest, Line, Col, NewRest, [T|Ts]);
+string_cont(Rest, Line, Col, skip_token, Ts) ->
+    do_string(Rest, Line, Col, Rest, Ts);
+string_cont(Rest, Line, Col, {skip_token,Push}, Ts) ->
     NewRest = Push ++ Rest,
-    string(NewRest, Line, NewRest, Ts);
-string_cont(_Rest, Line, {error,S}, _Ts) ->
-    {error,{Line,?MODULE,{user,S}},Line}.
+    do_string(NewRest, Line, Col, NewRest, Ts);
+string_cont(_Rest, Line, Col, {error,S}, _Ts) ->
+    {error,{{Line, Col},?MODULE,{user,S}},{Line,Col}}.
 
 %% token(Continuation, Chars) ->
-%% token(Continuation, Chars, Line) ->
+%% token(Continuation, Chars, Loc) ->
 %% {more,Continuation} | {done,ReturnVal,RestChars}.
 %% Must be careful when re-entering to append the latest characters to the
 %% after characters in an accept. The continuation is:
-%% {token,State,CurrLine,TokenChars,TokenLen,TokenLine,AccAction,AccLen}
+%% {token,State,CurrLine,CurrCol,TokenChars,TokenLen,TokenLine,TokenCol,AccAction,AccLen}
 
-token(Cont, Chars) -> token(Cont, Chars, 1).
+token(Cont,Chars) -> 
+    token(Cont,Chars,1).
+token(Cont, Chars, Line) -> 
+    case do_token(Cont,Chars,Line,1) of
+        {more, _} = C -> C;
+        {done, Ret0, R} ->
+            Ret1 = case Ret0 of
+                {ok, T, {L,_}} -> {ok, T, L};
+                {eof, {L,_}} -> {eof, L};
+                {error, {{EL,_},M,D},{L,_}} -> {error, {EL,M,D},L}
+            end,
+            {done, Ret1, R}
+    end.
 
-token([], Chars, Line) ->
-    token(yystate(), Chars, Line, Chars, 0, Line, reject, 0);
-token({token,State,Line,Tcs,Tlen,Tline,Action,Alen}, Chars, _) ->
-    token(State, Chars, Line, Tcs ++ Chars, Tlen, Tline, Action, Alen).
+do_token([], Chars, Line, Col) ->
+    token(yystate(), Chars, Line, Col, Chars, 0, Line, Col, reject, 0);
+do_token({token,State,Line,Col,Tcs,Tlen,Tline,Tcol,Action,Alen}, Chars, _, _) ->
+    token(State, Chars, Line, Col, Tcs ++ Chars, Tlen, Tline, Tcol, Action, Alen).
 
-%% token(State, InChars, Line, TokenChars, TokenLen, TokenLine,
+%% token(State, InChars, Line, Col, TokenChars, TokenLen, TokenLine, TokenCol
 %% AcceptAction, AcceptLen) ->
 %% {more,Continuation} | {done,ReturnVal,RestChars}.
 %% The argument order is chosen to be more efficient.
 
-token(S0, Ics0, L0, Tcs, Tlen0, Tline, A0, Alen0) ->
-    case yystate(S0, Ics0, L0, Tlen0, A0, Alen0) of
+token(S0, Ics0, L0, C0, Tcs, Tlen0, Tline, Tcol, A0, Alen0) ->
+    case yystate(S0, Ics0, L0, C0, Tlen0, A0, Alen0) of
         %% Accepting end state, we have a token.
-        {A1,Alen1,Ics1,L1} ->
-            token_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline));
+        {A1,Alen1,Ics1,L1,C1} ->
+            C2 = adjust_col(Tcs, Alen1, C1),
+            token_cont(Ics1, L1, C2, yyaction(A1, Alen1, Tcs, Tline,Tcol));
         %% Accepting transition state, can take more chars.
-        {A1,Alen1,[],L1,S1} ->                  % Need more chars to check
-            {more,{token,S1,L1,Tcs,Alen1,Tline,A1,Alen1}};
-        {A1,Alen1,Ics1,L1,_S1} ->               % Take what we got
-            token_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline));
+        {A1,Alen1,[],L1,C1,S1} ->                  % Need more chars to check
+            {more,{token,S1,L1,C1,Tcs,Alen1,Tline,Tcol,A1,Alen1}};
+        {A1,Alen1,Ics1,L1,C1,_S1} ->               % Take what we got
+            C2 = adjust_col(Tcs, Alen1, C1),
+            token_cont(Ics1, L1, C2, yyaction(A1, Alen1, Tcs, Tline,Tcol));
         %% After a non-accepting state, maybe reach accept state later.
-        {A1,Alen1,Tlen1,[],L1,S1} ->            % Need more chars to check
-            {more,{token,S1,L1,Tcs,Tlen1,Tline,A1,Alen1}};
-        {reject,_Alen1,Tlen1,eof,L1,_S1} ->     % No token match
+        {A1,Alen1,Tlen1,[],L1,C1,S1} ->            % Need more chars to check
+            {more,{token,S1,L1,C1,Tcs,Tlen1,Tline,Tcol,A1,Alen1}};
+        {reject,_Alen1,Tlen1,eof,L1,C1,_S1} ->     % No token match
             %% Check for partial token which is error.
-            Ret = if Tlen1 > 0 -> {error,{Tline,?MODULE,
+            Ret = if Tlen1 > 0 -> {error,{{Tline,Tcol},?MODULE,
                                           %% Skip eof tail in Tcs.
-                                          {illegal,yypre(Tcs, Tlen1)}},L1};
-                     true -> {eof,L1}
+                                          {illegal,yypre(Tcs, Tlen1)}},{L1,C1}};
+                     true -> {eof,{L1,C1}}
                   end,
             {done,Ret,eof};
-        {reject,_Alen1,Tlen1,Ics1,L1,_S1} ->    % No token match
-            Error = {Tline,?MODULE,{illegal,yypre(Tcs, Tlen1+1)}},
-            {done,{error,Error,L1},Ics1};
-        {A1,Alen1,Tlen1,_Ics1,L1,_S1} ->       % Use last accept match
+        {reject,_Alen1,Tlen1,Ics1,_L1,_C1,_S1} ->    % No token match
+            Error = {{Tline,Tcol},?MODULE,{illegal,yypre(Tcs, Tlen1+1)}},
+            {done,{error,Error,{Tline,Tcol}},Ics1};
+        {A1,Alen1,Tlen1,_Ics1,L1,_C1,_S1} ->       % Use last accept match
             Tcs1 = yysuf(Tcs, Alen1),
             L2 = adjust_line(Tlen1, Alen1, Tcs1, L1),
-            token_cont(Tcs1, L2, yyaction(A1, Alen1, Tcs, Tline))
+            C2 = C0 + Alen1,
+            token_cont(Tcs1, L2, C2, yyaction(A1, Alen1, Tcs, Tline, Tcol))
     end.
 
-%% token_cont(RestChars, Line, Token)
+%% token_cont(RestChars, Line, Col, Token)
 %% If we have a token or error then return done, else if we have a
 %% skip_token then continue.
 
--dialyzer({nowarn_function, token_cont/3}).
+-dialyzer({nowarn_function, token_cont/4}).
 
-token_cont(Rest, Line, {token,T}) ->
-    {done,{ok,T,Line},Rest};
-token_cont(Rest, Line, {token,T,Push}) ->
+token_cont(Rest, Line, Col, {token,T}) ->
+    {done,{ok,T,{Line,Col}},Rest};
+token_cont(Rest, Line, Col, {token,T,Push}) ->
     NewRest = Push ++ Rest,
-    {done,{ok,T,Line},NewRest};
-token_cont(Rest, Line, {end_token,T}) ->
-    {done,{ok,T,Line},Rest};
-token_cont(Rest, Line, {end_token,T,Push}) ->
+    {done,{ok,T,{Line,Col}},NewRest};
+token_cont(Rest, Line, Col, {end_token,T}) ->
+    {done,{ok,T,{Line,Col}},Rest};
+token_cont(Rest, Line, Col, {end_token,T,Push}) ->
     NewRest = Push ++ Rest,
-    {done,{ok,T,Line},NewRest};
-token_cont(Rest, Line, skip_token) ->
-    token(yystate(), Rest, Line, Rest, 0, Line, reject, 0);
-token_cont(Rest, Line, {skip_token,Push}) ->
+    {done,{ok,T,{Line,Col}},NewRest};
+token_cont(Rest, Line, Col, skip_token) ->
+    token(yystate(), Rest, Line, Col, Rest, 0, Line, Col, reject, 0);
+token_cont(Rest, Line, Col, {skip_token,Push}) ->
     NewRest = Push ++ Rest,
-    token(yystate(), NewRest, Line, NewRest, 0, Line, reject, 0);
-token_cont(Rest, Line, {error,S}) ->
-    {done,{error,{Line,?MODULE,{user,S}},Line},Rest}.
+    token(yystate(), NewRest, Line, Col, NewRest, 0, Line, Col, reject, 0);
+token_cont(Rest, Line, Col, {error,S}) ->
+    {done,{error,{{Line, Col},?MODULE,{user,S}},{Line, Col}},Rest}.
 
-%% tokens(Continuation, Chars, Line) ->
+%% tokens(Continuation, Chars) ->
+%% tokens(Continuation, Chars, Loc) ->
 %% {more,Continuation} | {done,ReturnVal,RestChars}.
 %% Must be careful when re-entering to append the latest characters to the
 %% after characters in an accept. The continuation is:
-%% {tokens,State,CurrLine,TokenChars,TokenLen,TokenLine,Tokens,AccAction,AccLen}
-%% {skip_tokens,State,CurrLine,TokenChars,TokenLen,TokenLine,Error,AccAction,AccLen}
+%% {tokens,State,CurrLine,CurrCol,TokenChars,TokenLen,TokenLine,TokenCur,Tokens,AccAction,AccLen}
+%% {skip_tokens,State,CurrLine,CurrCol,TokenChars,TokenLen,TokenLine,TokenCur,Error,AccAction,AccLen}
 
-tokens(Cont, Chars) -> tokens(Cont, Chars, 1).
+tokens(Cont,Chars) -> 
+    tokens(Cont,Chars,1).
+tokens(Cont, Chars, Line) -> 
+    case do_tokens(Cont,Chars,Line,1) of
+        {more, _} = C -> C;
+        {done, Ret0, R} ->
+            Ret1 = case Ret0 of
+                {ok, T, {L,_}} -> {ok, T, L};
+                {eof, {L,_}} -> {eof, L};
+                {error, {{EL,_},M,D},{L,_}} -> {error, {EL,M,D},L}
+            end,
+            {done, Ret1, R}
+    end.
 
-tokens([], Chars, Line) ->
-    tokens(yystate(), Chars, Line, Chars, 0, Line, [], reject, 0);
-tokens({tokens,State,Line,Tcs,Tlen,Tline,Ts,Action,Alen}, Chars, _) ->
-    tokens(State, Chars, Line, Tcs ++ Chars, Tlen, Tline, Ts, Action, Alen);
-tokens({skip_tokens,State,Line,Tcs,Tlen,Tline,Error,Action,Alen}, Chars, _) ->
-    skip_tokens(State, Chars, Line, Tcs ++ Chars, Tlen, Tline, Error, Action, Alen).
+do_tokens([], Chars, Line, Col) ->
+    tokens(yystate(), Chars, Line, Col, Chars, 0, Line, Col, [], reject, 0);
+do_tokens({tokens,State,Line,Col,Tcs,Tlen,Tline,Tcol,Ts,Action,Alen}, Chars, _,_) ->
+    tokens(State, Chars, Line, Col, Tcs ++ Chars, Tlen, Tline, Tcol, Ts, Action, Alen);
+do_tokens({skip_tokens,State,Line, Col, Tcs,Tlen,Tline,Tcol,Error,Action,Alen}, Chars, _,_) ->
+    skip_tokens(State, Chars, Line, Col, Tcs ++ Chars, Tlen, Tline, Tcol, Error, Action, Alen).
 
-%% tokens(State, InChars, Line, TokenChars, TokenLen, TokenLine, Tokens,
+%% tokens(State, InChars, Line, Col, TokenChars, TokenLen, TokenLine, TokenCol,Tokens,
 %% AcceptAction, AcceptLen) ->
 %% {more,Continuation} | {done,ReturnVal,RestChars}.
 
-tokens(S0, Ics0, L0, Tcs, Tlen0, Tline, Ts, A0, Alen0) ->
-    case yystate(S0, Ics0, L0, Tlen0, A0, Alen0) of
+tokens(S0, Ics0, L0, C0, Tcs, Tlen0, Tline, Tcol, Ts, A0, Alen0) ->
+    case yystate(S0, Ics0, L0, C0, Tlen0, A0, Alen0) of
         %% Accepting end state, we have a token.
-        {A1,Alen1,Ics1,L1} ->
-            tokens_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Ts);
+        {A1,Alen1,Ics1,L1,C1} ->
+            C2 = adjust_col(Tcs, Alen1, C1),
+            tokens_cont(Ics1, L1, C2, yyaction(A1, Alen1, Tcs, Tline, Tcol), Ts);
         %% Accepting transition state, can take more chars.
-        {A1,Alen1,[],L1,S1} ->                  % Need more chars to check
-            {more,{tokens,S1,L1,Tcs,Alen1,Tline,Ts,A1,Alen1}};
-        {A1,Alen1,Ics1,L1,_S1} ->               % Take what we got
-            tokens_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Ts);
+        {A1,Alen1,[],L1,C1,S1} ->                  % Need more chars to check
+            {more,{tokens,S1,L1,C1,Tcs,Alen1,Tline,Tcol,Ts,A1,Alen1}};
+        {A1,Alen1,Ics1,L1,C1,_S1} ->               % Take what we got
+            C2 = adjust_col(Tcs, Alen1, C1),
+            tokens_cont(Ics1, L1, C2, yyaction(A1, Alen1, Tcs, Tline,Tcol), Ts);
         %% After a non-accepting state, maybe reach accept state later.
-        {A1,Alen1,Tlen1,[],L1,S1} ->            % Need more chars to check
-            {more,{tokens,S1,L1,Tcs,Tlen1,Tline,Ts,A1,Alen1}};
-        {reject,_Alen1,Tlen1,eof,L1,_S1} ->     % No token match
+        {A1,Alen1,Tlen1,[],L1,C1,S1} ->            % Need more chars to check
+            {more,{tokens,S1,L1,C1,Tcs,Tlen1,Tline,Tcol,Ts,A1,Alen1}};
+        {reject,_Alen1,Tlen1,eof,L1,C1,_S1} ->     % No token match
             %% Check for partial token which is error, no need to skip here.
-            Ret = if Tlen1 > 0 -> {error,{Tline,?MODULE,
+            Ret = if Tlen1 > 0 -> {error,{{Tline,Tcol},?MODULE,
                                           %% Skip eof tail in Tcs.
-                                          {illegal,yypre(Tcs, Tlen1)}},L1};
-                     Ts == [] -> {eof,L1};
-                     true -> {ok,yyrev(Ts),L1}
+                                          {illegal,yypre(Tcs, Tlen1)}},{L1,C1}};
+                     Ts == [] -> {eof,{L1,C1}};
+                     true -> {ok,yyrev(Ts),{L1,C1}}
                   end,
             {done,Ret,eof};
-        {reject,_Alen1,Tlen1,_Ics1,L1,_S1} ->
+        {reject,_Alen1,Tlen1,_Ics1,L1,C1,_S1} ->
             %% Skip rest of tokens.
-            Error = {L1,?MODULE,{illegal,yypre(Tcs, Tlen1+1)}},
-            skip_tokens(yysuf(Tcs, Tlen1+1), L1, Error);
-        {A1,Alen1,Tlen1,_Ics1,L1,_S1} ->
-            Token = yyaction(A1, Alen1, Tcs, Tline),
+            Error = {{L1,C1},?MODULE,{illegal,yypre(Tcs, Tlen1+1)}},
+            skip_tokens(yysuf(Tcs, Tlen1+1), L1, C1, Error);
+        {A1,Alen1,Tlen1,_Ics1,L1,_C1,_S1} ->
+            Token = yyaction(A1, Alen1, Tcs, Tline,Tcol),
             Tcs1 = yysuf(Tcs, Alen1),
             L2 = adjust_line(Tlen1, Alen1, Tcs1, L1),
-            tokens_cont(Tcs1, L2, Token, Ts)
+            C2 = C0 + Alen1,
+            tokens_cont(Tcs1, L2, C2, Token, Ts)
     end.
 
-%% tokens_cont(RestChars, Line, Token, Tokens)
+%% tokens_cont(RestChars, Line, Column, Token, Tokens)
 %% If we have an end_token or error then return done, else if we have
 %% a token then save it and continue, else if we have a skip_token
 %% just continue.
 
--dialyzer({nowarn_function, tokens_cont/4}).
+-dialyzer({nowarn_function, tokens_cont/5}).
 
-tokens_cont(Rest, Line, {token,T}, Ts) ->
-    tokens(yystate(), Rest, Line, Rest, 0, Line, [T|Ts], reject, 0);
-tokens_cont(Rest, Line, {token,T,Push}, Ts) ->
+tokens_cont(Rest, Line, Col, {token,T}, Ts) ->
+    tokens(yystate(), Rest, Line, Col, Rest, 0, Line, Col, [T|Ts], reject, 0);
+tokens_cont(Rest, Line, Col, {token,T,Push}, Ts) ->
     NewRest = Push ++ Rest,
-    tokens(yystate(), NewRest, Line, NewRest, 0, Line, [T|Ts], reject, 0);
-tokens_cont(Rest, Line, {end_token,T}, Ts) ->
-    {done,{ok,yyrev(Ts, [T]),Line},Rest};
-tokens_cont(Rest, Line, {end_token,T,Push}, Ts) ->
+    tokens(yystate(), NewRest, Line, Col, NewRest, 0, Line, Col, [T|Ts], reject, 0);
+tokens_cont(Rest, Line, Col, {end_token,T}, Ts) ->
+    {done,{ok,yyrev(Ts, [T]),{Line,Col}},Rest};
+tokens_cont(Rest, Line, Col, {end_token,T,Push}, Ts) ->
     NewRest = Push ++ Rest,
-    {done,{ok,yyrev(Ts, [T]),Line},NewRest};
-tokens_cont(Rest, Line, skip_token, Ts) ->
-    tokens(yystate(), Rest, Line, Rest, 0, Line, Ts, reject, 0);
-tokens_cont(Rest, Line, {skip_token,Push}, Ts) ->
+    {done,{ok,yyrev(Ts, [T]),{Line, Col}},NewRest};
+tokens_cont(Rest, Line, Col, skip_token, Ts) ->
+    tokens(yystate(), Rest, Line, Col, Rest, 0, Line, Col, Ts, reject, 0);
+tokens_cont(Rest, Line, Col, {skip_token,Push}, Ts) ->
     NewRest = Push ++ Rest,
-    tokens(yystate(), NewRest, Line, NewRest, 0, Line, Ts, reject, 0);
-tokens_cont(Rest, Line, {error,S}, _Ts) ->
-    skip_tokens(Rest, Line, {Line,?MODULE,{user,S}}).
+    tokens(yystate(), NewRest, Line, Col, NewRest, 0, Line, Col, Ts, reject, 0);
+tokens_cont(Rest, Line, Col, {error,S}, _Ts) ->
+    skip_tokens(Rest, Line, Col, {{Line,Col},?MODULE,{user,S}}).
 
-%%skip_tokens(InChars, Line, Error) -> {done,{error,Error,Line},Ics}.
+%% skip_tokens(InChars, Line, Col, Error) -> {done,{error,Error,{Line,Col}},Ics}.
 %% Skip tokens until an end token, junk everything and return the error.
 
-skip_tokens(Ics, Line, Error) ->
-    skip_tokens(yystate(), Ics, Line, Ics, 0, Line, Error, reject, 0).
+skip_tokens(Ics, Line, Col, Error) ->
+    skip_tokens(yystate(), Ics, Line, Col, Ics, 0, Line, Col, Error, reject, 0).
 
-%% skip_tokens(State, InChars, Line, TokenChars, TokenLen, TokenLine, Tokens,
+%% skip_tokens(State, InChars, Line, Col, TokenChars, TokenLen, TokenLine, TokenCol, Tokens,
 %% AcceptAction, AcceptLen) ->
 %% {more,Continuation} | {done,ReturnVal,RestChars}.
 
-skip_tokens(S0, Ics0, L0, Tcs, Tlen0, Tline, Error, A0, Alen0) ->
-    case yystate(S0, Ics0, L0, Tlen0, A0, Alen0) of
-        {A1,Alen1,Ics1,L1} ->                  % Accepting end state
-            skip_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Error);
-        {A1,Alen1,[],L1,S1} ->                 % After an accepting state
-            {more,{skip_tokens,S1,L1,Tcs,Alen1,Tline,Error,A1,Alen1}};
-        {A1,Alen1,Ics1,L1,_S1} ->
-            skip_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Error);
-        {A1,Alen1,Tlen1,[],L1,S1} ->           % After a non-accepting state
-            {more,{skip_tokens,S1,L1,Tcs,Tlen1,Tline,Error,A1,Alen1}};
-        {reject,_Alen1,_Tlen1,eof,L1,_S1} ->
-            {done,{error,Error,L1},eof};
-        {reject,_Alen1,Tlen1,_Ics1,L1,_S1} ->
-            skip_tokens(yysuf(Tcs, Tlen1+1), L1, Error);
-        {A1,Alen1,Tlen1,_Ics1,L1,_S1} ->
-            Token = yyaction(A1, Alen1, Tcs, Tline),
+skip_tokens(S0, Ics0, L0, C0, Tcs, Tlen0, Tline, Tcol, Error, A0, Alen0) ->
+    case yystate(S0, Ics0, L0, C0, Tlen0, A0, Alen0) of
+        {A1,Alen1,Ics1,L1, C1} ->                  % Accepting end state
+            skip_cont(Ics1, L1, C1, yyaction(A1, Alen1, Tcs, Tline, Tcol), Error);
+        {A1,Alen1,[],L1,C1, S1} ->                 % After an accepting state
+            {more,{skip_tokens,S1,L1,C1,Tcs,Alen1,Tline,Tcol,Error,A1,Alen1}};
+        {A1,Alen1,Ics1,L1,C1,_S1} ->
+            skip_cont(Ics1, L1, C1, yyaction(A1, Alen1, Tcs, Tline, Tcol), Error);
+        {A1,Alen1,Tlen1,[],L1,C1,S1} ->           % After a non-accepting state
+            {more,{skip_tokens,S1,L1,C1,Tcs,Tlen1,Tline,Tcol,Error,A1,Alen1}};
+        {reject,_Alen1,_Tlen1,eof,L1,C1,_S1} ->
+            {done,{error,Error,{L1,C1}},eof};
+        {reject,_Alen1,Tlen1,_Ics1,L1,C1,_S1} ->
+            skip_tokens(yysuf(Tcs, Tlen1+1), L1, C1,Error);
+        {A1,Alen1,Tlen1,_Ics1,L1,C1,_S1} ->
+            Token = yyaction(A1, Alen1, Tcs, Tline, Tcol),
             Tcs1 = yysuf(Tcs, Alen1),
             L2 = adjust_line(Tlen1, Alen1, Tcs1, L1),
-            skip_cont(Tcs1, L2, Token, Error)
+            skip_cont(Tcs1, L2, C1, Token, Error)
     end.
 
-%% skip_cont(RestChars, Line, Token, Error)
+%% skip_cont(RestChars, Line, Col, Token, Error)
 %% Skip tokens until we have an end_token or error then return done
 %% with the original rror.
 
--dialyzer({nowarn_function, skip_cont/4}).
+-dialyzer({nowarn_function, skip_cont/5}).
 
-skip_cont(Rest, Line, {token,_T}, Error) ->
-    skip_tokens(yystate(), Rest, Line, Rest, 0, Line, Error, reject, 0);
-skip_cont(Rest, Line, {token,_T,Push}, Error) ->
+skip_cont(Rest, Line, Col, {token,_T}, Error) ->
+    skip_tokens(yystate(), Rest, Line, Col, Rest, 0, Line, Col, Error, reject, 0);
+skip_cont(Rest, Line, Col, {token,_T,Push}, Error) ->
     NewRest = Push ++ Rest,
-    skip_tokens(yystate(), NewRest, Line, NewRest, 0, Line, Error, reject, 0);
-skip_cont(Rest, Line, {end_token,_T}, Error) ->
-    {done,{error,Error,Line},Rest};
-skip_cont(Rest, Line, {end_token,_T,Push}, Error) ->
+    skip_tokens(yystate(), NewRest, Line, Col, NewRest, 0, Line, Col, Error, reject, 0);
+skip_cont(Rest, Line, Col, {end_token,_T}, Error) ->
+    {done,{error,Error,{Line,Col}},Rest};
+skip_cont(Rest, Line, Col, {end_token,_T,Push}, Error) ->
     NewRest = Push ++ Rest,
-    {done,{error,Error,Line},NewRest};
-skip_cont(Rest, Line, skip_token, Error) ->
-    skip_tokens(yystate(), Rest, Line, Rest, 0, Line, Error, reject, 0);
-skip_cont(Rest, Line, {skip_token,Push}, Error) ->
+    {done,{error,Error,{Line,Col}},NewRest};
+skip_cont(Rest, Line, Col, skip_token, Error) ->
+    skip_tokens(yystate(), Rest, Line, Col, Rest, 0, Line, Col, Error, reject, 0);
+skip_cont(Rest, Line, Col, {skip_token,Push}, Error) ->
     NewRest = Push ++ Rest,
-    skip_tokens(yystate(), NewRest, Line, NewRest, 0, Line, Error, reject, 0);
-skip_cont(Rest, Line, {error,_S}, Error) ->
-    skip_tokens(yystate(), Rest, Line, Rest, 0, Line, Error, reject, 0).
+    skip_tokens(yystate(), NewRest, Line, Col, NewRest, 0, Line, Col, Error, reject, 0);
+skip_cont(Rest, Line, Col, {error,_S}, Error) ->
+    skip_tokens(yystate(), Rest, Line, Col, Rest, 0, Line, Col, Error, reject, 0).
 
 -compile({nowarn_unused_function, [yyrev/1, yyrev/2, yypre/2, yysuf/2]}).
 
@@ -310,1642 +352,1666 @@ adjust_line(T, A, [$\n|Cs], L) ->
 adjust_line(T, A, [_|Cs], L) ->
     adjust_line(T-1, A, Cs, L).
 
+%% adjust_col(Chars, AcceptLength, Col) -> NewCol
+%% Handle newlines, tabs and unicode chars.
+adjust_col(_, 0, Col) ->
+    Col;
+adjust_col([$\n | R], L, _) ->
+    adjust_col(R, L-1, 1);
+adjust_col([$\t | R], L, Col) ->
+    adjust_col(R, L-1, tab_forward(Col)+1);
+adjust_col([C | R], L, Col) when C>=0 andalso C=< 16#7F ->
+    adjust_col(R, L-1, Col+1);
+adjust_col([C | R], L, Col) when C>= 16#80 andalso C=< 16#7FF ->
+    adjust_col(R, L-1, Col+2);
+adjust_col([C | R], L, Col) when C>= 16#800 andalso C=< 16#FFFF ->
+    adjust_col(R, L-1, Col+3);
+adjust_col([C | R], L, Col) when C>= 16#10000 andalso C=< 16#10FFFF ->
+    adjust_col(R, L-1, Col+4).
+
+tab_forward(C) ->
+    D = C rem tab_size(),
+    A = tab_size()-D,
+    C+A.
+
+tab_size() -> 8.
+
 %% yystate() -> InitialState.
-%% yystate(State, InChars, Line, CurrTokLen, AcceptAction, AcceptLen) ->
-%% {Action, AcceptLen, RestChars, Line} |
-%% {Action, AcceptLen, RestChars, Line, State} |
-%% {reject, AcceptLen, CurrTokLen, RestChars, Line, State} |
-%% {Action, AcceptLen, CurrTokLen, RestChars, Line, State}.
+%% yystate(State, InChars, Line, Col, CurrTokLen, AcceptAction, AcceptLen) ->
+%% {Action, AcceptLen, RestChars, Line, Col} |
+%% {Action, AcceptLen, RestChars, Line, Col, State} |
+%% {reject, AcceptLen, CurrTokLen, RestChars, Line, Col, State} |
+%% {Action, AcceptLen, CurrTokLen, RestChars, Line, Col, State}.
 %% Generated state transition functions. The non-accepting end state
 %% return signal either an unrecognised character or end of current
 %% input.
 
--file("src/when_lexer.erl", 322).
+-file("src/when_lexer.erl", 354).
 yystate() -> 93.
 
-yystate(100, [108|Ics], Line, Tlen, _, _) ->
-    yystate(92, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(100, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,100};
-yystate(99, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, [71|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 70 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, [C|Ics], Line, Tlen, _, _) when C >= 72, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(99, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,99};
-yystate(98, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, [76|Ics], Line, Tlen, _, _) ->
-    yystate(90, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(98, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,98};
-yystate(97, [32|Ics], Line, Tlen, _, _) ->
-    yystate(97, Ics, Line, Tlen+1, 16, Tlen);
-yystate(97, [13|Ics], Line, Tlen, _, _) ->
-    yystate(97, Ics, Line, Tlen+1, 16, Tlen);
-yystate(97, [9|Ics], Line, Tlen, _, _) ->
-    yystate(97, Ics, Line, Tlen+1, 16, Tlen);
-yystate(97, [10|Ics], Line, Tlen, _, _) ->
-    yystate(97, Ics, Line+1, Tlen+1, 16, Tlen);
-yystate(97, Ics, Line, Tlen, _, _) ->
-    {16,Tlen,Ics,Line,97};
-yystate(96, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(96, [65|Ics], Line, Tlen, _, _) ->
-    yystate(98, Ics, Line, Tlen+1, 14, Tlen);
-yystate(96, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(96, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(96, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(96, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(96, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(96, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,96};
-yystate(95, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, [69|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(95, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,95};
-yystate(94, [108|Ics], Line, Tlen, _, _) ->
-    yystate(100, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(94, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,94};
-yystate(93, [125|Ics], Line, Tlen, Action, Alen) ->
-    yystate(85, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [123|Ics], Line, Tlen, Action, Alen) ->
-    yystate(77, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [116|Ics], Line, Tlen, Action, Alen) ->
-    yystate(69, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(5, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [113|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [112|Ics], Line, Tlen, Action, Alen) ->
-    yystate(86, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [111|Ics], Line, Tlen, Action, Alen) ->
-    yystate(28, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [102|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [98|Ics], Line, Tlen, Action, Alen) ->
-    yystate(7, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(47, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [93|Ics], Line, Tlen, Action, Alen) ->
-    yystate(63, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [91|Ics], Line, Tlen, Action, Alen) ->
-    yystate(71, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [84|Ics], Line, Tlen, Action, Alen) ->
-    yystate(79, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [83|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [82|Ics], Line, Tlen, Action, Alen) ->
-    yystate(91, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [81|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [80|Ics], Line, Tlen, Action, Alen) ->
-    yystate(0, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [79|Ics], Line, Tlen, Action, Alen) ->
-    yystate(88, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [70|Ics], Line, Tlen, Action, Alen) ->
-    yystate(96, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [66|Ics], Line, Tlen, Action, Alen) ->
-    yystate(78, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [65|Ics], Line, Tlen, Action, Alen) ->
-    yystate(38, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(14, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [48|Ics], Line, Tlen, Action, Alen) ->
-    yystate(17, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [45|Ics], Line, Tlen, Action, Alen) ->
-    yystate(25, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [44|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [41|Ics], Line, Tlen, Action, Alen) ->
-    yystate(41, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [40|Ics], Line, Tlen, Action, Alen) ->
-    yystate(49, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [39|Ics], Line, Tlen, Action, Alen) ->
-    yystate(57, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [33|Ics], Line, Tlen, Action, Alen) ->
-    yystate(81, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(97, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [13|Ics], Line, Tlen, Action, Alen) ->
-    yystate(97, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(97, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(97, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(93, [C|Ics], Line, Tlen, Action, Alen) when C >= 49, C =< 57 ->
-    yystate(6, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [C|Ics], Line, Tlen, Action, Alen) when C >= 67, C =< 69 ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [C|Ics], Line, Tlen, Action, Alen) when C >= 71, C =< 78 ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [C|Ics], Line, Tlen, Action, Alen) when C >= 85, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [C|Ics], Line, Tlen, Action, Alen) when C >= 99, C =< 101 ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [C|Ics], Line, Tlen, Action, Alen) when C >= 103, C =< 110 ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(93, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,93};
-yystate(92, [95|Ics], Line, Tlen, _, _) ->
-    yystate(84, Ics, Line, Tlen+1, 14, Tlen);
-yystate(92, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(92, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(92, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(92, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(92, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(92, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,92};
-yystate(91, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, [69|Ics], Line, Tlen, _, _) ->
-    yystate(83, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(91, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,91};
-yystate(90, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, [83|Ics], Line, Tlen, _, _) ->
-    yystate(95, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(90, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,90};
-yystate(89, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line};
-yystate(88, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, [82|Ics], Line, Tlen, _, _) ->
-    yystate(22, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(88, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,88};
-yystate(87, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, [85|Ics], Line, Tlen, _, _) ->
-    yystate(95, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(87, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,87};
-yystate(86, [117|Ics], Line, Tlen, _, _) ->
-    yystate(94, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(86, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,86};
-yystate(85, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line};
-yystate(84, [114|Ics], Line, Tlen, _, _) ->
-    yystate(76, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(84, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,84};
-yystate(83, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, [83|Ics], Line, Tlen, _, _) ->
-    yystate(75, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(83, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,83};
-yystate(82, [110|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(82, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,82};
-yystate(81, [126|Ics], Line, Tlen, Action, Alen) ->
-    yystate(89, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(89, Ics, Line, Tlen+1, Action, Alen);
-yystate(81, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,81};
-yystate(80, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, [84|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 83 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 85, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(80, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,80};
-yystate(79, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [82|Ics], Line, Tlen, _, _) ->
-    yystate(87, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [65|Ics], Line, Tlen, _, _) ->
-    yystate(99, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 81 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(79, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,79};
-yystate(78, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, [82|Ics], Line, Tlen, _, _) ->
-    yystate(70, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(78, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,78};
-yystate(77, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line};
-yystate(76, [101|Ics], Line, Tlen, _, _) ->
-    yystate(68, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(76, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,76};
-yystate(75, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, [85|Ics], Line, Tlen, _, _) ->
-    yystate(67, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(75, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,75};
-yystate(74, [111|Ics], Line, Tlen, _, _) ->
-    yystate(82, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(74, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,74};
-yystate(73, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line};
-yystate(72, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, [83|Ics], Line, Tlen, _, _) ->
-    yystate(80, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(72, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,72};
-yystate(71, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line};
-yystate(70, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(70, [65|Ics], Line, Tlen, _, _) ->
-    yystate(62, Ics, Line, Tlen+1, 14, Tlen);
-yystate(70, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(70, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(70, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(70, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,70};
-yystate(69, [114|Ics], Line, Tlen, _, _) ->
-    yystate(61, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [97|Ics], Line, Tlen, _, _) ->
-    yystate(37, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 113 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(69, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,69};
-yystate(68, [113|Ics], Line, Tlen, _, _) ->
-    yystate(60, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 112 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 114, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(68, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,68};
-yystate(67, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, [76|Ics], Line, Tlen, _, _) ->
-    yystate(59, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(67, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,67};
-yystate(66, [115|Ics], Line, Tlen, _, _) ->
-    yystate(74, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(66, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,66};
-yystate(65, [39|Ics], Line, Tlen, Action, Alen) ->
-    yystate(73, Ics, Line, Tlen+1, Action, Alen);
-yystate(65, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(65, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(65, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(65, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 38 ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(65, [C|Ics], Line, Tlen, Action, Alen) when C >= 40 ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(65, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,65};
-yystate(64, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, [69|Ics], Line, Tlen, _, _) ->
-    yystate(72, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(64, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,64};
-yystate(63, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line};
-yystate(62, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, [78|Ics], Line, Tlen, _, _) ->
-    yystate(54, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 79, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(62, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,62};
-yystate(61, [117|Ics], Line, Tlen, _, _) ->
-    yystate(53, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(61, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,61};
-yystate(60, [117|Ics], Line, Tlen, _, _) ->
-    yystate(52, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(60, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,60};
-yystate(59, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, [84|Ics], Line, Tlen, _, _) ->
-    yystate(51, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 83 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 85, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(59, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,59};
-yystate(58, [97|Ics], Line, Tlen, _, _) ->
-    yystate(66, Ics, Line, Tlen+1, 14, Tlen);
-yystate(58, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(58, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(58, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(58, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,58};
-yystate(57, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(65, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 38 ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 40 ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(57, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,57};
-yystate(56, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, [85|Ics], Line, Tlen, _, _) ->
-    yystate(64, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(56, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,56};
-yystate(55, [100|Ics], Line, Tlen, _, _) ->
-    yystate(22, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 99 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 101, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(55, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,55};
-yystate(54, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [67|Ics], Line, Tlen, _, _) ->
-    yystate(46, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [65|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [66|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 68, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(54, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,54};
-yystate(53, [101|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(53, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,53};
-yystate(52, [101|Ics], Line, Tlen, _, _) ->
-    yystate(44, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(52, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,52};
-yystate(51, [95|Ics], Line, Tlen, _, _) ->
-    yystate(43, Ics, Line, Tlen+1, 9, Tlen);
-yystate(51, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 9, Tlen);
-yystate(51, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(51, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,51};
-yystate(50, [101|Ics], Line, Tlen, _, _) ->
-    yystate(58, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(50, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,50};
-yystate(49, Ics, Line, Tlen, _, _) ->
-    {2,Tlen,Ics,Line};
-yystate(48, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, [81|Ics], Line, Tlen, _, _) ->
-    yystate(56, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 80 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 82, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(48, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,48};
-yystate(47, [110|Ics], Line, Tlen, _, _) ->
-    yystate(55, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(47, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,47};
-yystate(46, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, [72|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 71 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 73, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(46, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,46};
-yystate(45, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 10, Tlen);
-yystate(45, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 10, Tlen);
-yystate(45, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 10, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 10, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 10, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 10, Tlen);
-yystate(45, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line,45};
-yystate(44, [115|Ics], Line, Tlen, _, _) ->
-    yystate(36, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(44, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,44};
-yystate(43, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, [82|Ics], Line, Tlen, _, _) ->
-    yystate(35, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(43, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,43};
-yystate(42, [114|Ics], Line, Tlen, _, _) ->
-    yystate(50, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(42, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,42};
-yystate(41, Ics, Line, Tlen, _, _) ->
-    {3,Tlen,Ics,Line};
-yystate(40, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, [69|Ics], Line, Tlen, _, _) ->
-    yystate(48, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(40, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,40};
-yystate(39, [104|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 103 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 105, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(39, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,39};
-yystate(38, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, [78|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 79, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(38, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,38};
-yystate(37, [103|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(37, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,37};
-yystate(36, [116|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(36, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,36};
-yystate(35, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, [69|Ics], Line, Tlen, _, _) ->
-    yystate(27, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 68 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 70, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(35, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,35};
-yystate(34, [95|Ics], Line, Tlen, _, _) ->
-    yystate(42, Ics, Line, Tlen+1, 9, Tlen);
-yystate(34, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 9, Tlen);
-yystate(34, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(34, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,34};
-yystate(33, Ics, Line, Tlen, _, _) ->
-    {8,Tlen,Ics,Line};
-yystate(32, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, [82|Ics], Line, Tlen, _, _) ->
-    yystate(40, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 81 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 83, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(32, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,32};
-yystate(31, [99|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [97|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [98|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(31, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,31};
-yystate(30, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, [68|Ics], Line, Tlen, _, _) ->
-    yystate(22, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 67 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 69, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(30, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,30};
-yystate(29, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(29, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 9, Tlen);
-yystate(29, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 9, Tlen);
-yystate(29, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,29};
-yystate(28, [114|Ics], Line, Tlen, _, _) ->
-    yystate(22, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(28, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,28};
-yystate(27, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(27, [65|Ics], Line, Tlen, _, _) ->
-    yystate(19, Ics, Line, Tlen+1, 14, Tlen);
-yystate(27, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(27, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 66, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(27, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,27};
-yystate(26, [116|Ics], Line, Tlen, _, _) ->
-    yystate(34, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(26, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,26};
-yystate(25, [48|Ics], Line, Tlen, Action, Alen) ->
-    yystate(17, Ics, Line, Tlen+1, Action, Alen);
-yystate(25, [C|Ics], Line, Tlen, Action, Alen) when C >= 49, C =< 57 ->
-    yystate(6, Ics, Line, Tlen+1, Action, Alen);
-yystate(25, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,25};
-yystate(24, [95|Ics], Line, Tlen, _, _) ->
-    yystate(32, Ics, Line, Tlen+1, 14, Tlen);
-yystate(24, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(24, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(24, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,24};
-yystate(23, [110|Ics], Line, Tlen, _, _) ->
-    yystate(31, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(23, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,23};
-yystate(22, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 1, Tlen);
-yystate(22, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 1, Tlen);
-yystate(22, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 1, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 1, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 1, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 1, Tlen);
-yystate(22, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line,22};
-yystate(21, Ics, Line, Tlen, _, _) ->
-    {15,Tlen,Ics,Line};
-yystate(20, [97|Ics], Line, Tlen, _, _) ->
-    yystate(12, Ics, Line, Tlen+1, 14, Tlen);
-yystate(20, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(20, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(20, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(20, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,20};
-yystate(19, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, [83|Ics], Line, Tlen, _, _) ->
-    yystate(11, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 82 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 84, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(19, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,19};
-yystate(18, [108|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(18, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,18};
-yystate(17, Ics, Line, Tlen, _, _) ->
-    {12,Tlen,Ics,Line};
-yystate(16, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, [76|Ics], Line, Tlen, _, _) ->
-    yystate(24, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(16, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,16};
-yystate(15, [97|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 14, Tlen);
-yystate(15, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(15, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(15, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(15, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,15};
-yystate(14, [126|Ics], Line, Tlen, _, _) ->
-    yystate(89, Ics, Line, Tlen+1, 0, Tlen);
-yystate(14, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line,14};
-yystate(13, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(13, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(13, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(13, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,13};
-yystate(12, [108|Ics], Line, Tlen, _, _) ->
-    yystate(4, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(12, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,12};
-yystate(11, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, [79|Ics], Line, Tlen, _, _) ->
-    yystate(3, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 78 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 80, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(11, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,11};
-yystate(10, [117|Ics], Line, Tlen, _, _) ->
-    yystate(18, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(10, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,10};
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(9, Ics, Line, Tlen+1, 13, Tlen);
-yystate(9, Ics, Line, Tlen, _, _) ->
-    {13,Tlen,Ics,Line,9};
-yystate(8, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, [76|Ics], Line, Tlen, _, _) ->
-    yystate(16, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 75 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 77, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(8, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,8};
-yystate(7, [114|Ics], Line, Tlen, _, _) ->
-    yystate(15, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(7, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,7};
-yystate(6, [46|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 12, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(6, Ics, Line, Tlen+1, 12, Tlen);
-yystate(6, Ics, Line, Tlen, _, _) ->
-    {12,Tlen,Ics,Line,6};
-yystate(5, [101|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(5, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,5};
-yystate(4, [115|Ics], Line, Tlen, _, _) ->
-    yystate(53, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(4, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,4};
-yystate(3, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, [78|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 77 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 79, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(3, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,3};
-yystate(2, [115|Ics], Line, Tlen, _, _) ->
-    yystate(10, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(2, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,2};
-yystate(1, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(9, Ics, Line, Tlen+1, Action, Alen);
-yystate(1, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,1};
-yystate(0, [95|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, [85|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, [58|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, [45|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 84 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 86, C =< 90 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(13, Ics, Line, Tlen+1, 14, Tlen);
-yystate(0, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line,0};
-yystate(S, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,S}.
+yystate(100, [108|Ics], Line, Col, Tlen, _, _) ->
+    yystate(92, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, [C|Ics], Line, Col, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(100, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,100};
+yystate(99, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, [71|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 70 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, [C|Ics], Line, Col, Tlen, _, _) when C >= 72, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(99, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,99};
+yystate(98, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, [76|Ics], Line, Col, Tlen, _, _) ->
+    yystate(90, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, [C|Ics], Line, Col, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(98, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,98};
+yystate(97, [32|Ics], Line, Col, Tlen, _, _) ->
+    yystate(97, Ics, Line, Col, Tlen+1, 16, Tlen);
+yystate(97, [13|Ics], Line, Col, Tlen, _, _) ->
+    yystate(97, Ics, Line, Col, Tlen+1, 16, Tlen);
+yystate(97, [9|Ics], Line, Col, Tlen, _, _) ->
+    yystate(97, Ics, Line, Col, Tlen+1, 16, Tlen);
+yystate(97, [10|Ics], Line, _, Tlen, _, _) ->
+    yystate(97, Ics, Line+1, 1, Tlen+1, 16, Tlen);
+yystate(97, Ics, Line, Col, Tlen, _, _) ->
+    {16,Tlen,Ics,Line,Col,97};
+yystate(96, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(96, [65|Ics], Line, Col, Tlen, _, _) ->
+    yystate(98, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(96, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(96, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(96, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(96, [C|Ics], Line, Col, Tlen, _, _) when C >= 66, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(96, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(96, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,96};
+yystate(95, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, [69|Ics], Line, Col, Tlen, _, _) ->
+    yystate(45, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, [C|Ics], Line, Col, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(95, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,95};
+yystate(94, [108|Ics], Line, Col, Tlen, _, _) ->
+    yystate(100, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, [C|Ics], Line, Col, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(94, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,94};
+yystate(93, [125|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(85, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [123|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(77, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [116|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(69, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [115|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [114|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(5, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [113|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [112|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(86, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [111|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(28, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [102|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(20, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [98|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(7, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [97|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(47, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [93|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(63, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [91|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(71, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [84|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(79, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [83|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [82|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(91, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [81|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [80|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(0, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [79|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(88, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [70|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(96, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [66|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(78, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [65|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(38, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [61|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(14, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [48|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(17, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [45|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(25, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [44|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(33, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [41|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(41, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [40|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(49, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [39|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(57, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [33|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(81, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [32|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(97, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [13|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(97, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [9|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(97, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [10|Ics], Line, _, Tlen, Action, Alen) ->
+    yystate(97, Ics, Line+1, 1, Tlen+1, Action, Alen);
+yystate(93, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 49, C =< 57 ->
+    yystate(6, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 67, C =< 69 ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 71, C =< 78 ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 85, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 99, C =< 101 ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 103, C =< 110 ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 117, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(93, Ics, Line, Col, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,Col,93};
+yystate(92, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(84, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(92, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(92, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(92, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(92, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(92, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(92, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,92};
+yystate(91, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, [69|Ics], Line, Col, Tlen, _, _) ->
+    yystate(83, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, [C|Ics], Line, Col, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(91, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,91};
+yystate(90, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, [83|Ics], Line, Col, Tlen, _, _) ->
+    yystate(95, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, [C|Ics], Line, Col, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(90, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,90};
+yystate(89, Ics, Line, Col, Tlen, _, _) ->
+    {0,Tlen,Ics,Line,Col};
+yystate(88, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, [82|Ics], Line, Col, Tlen, _, _) ->
+    yystate(22, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, [C|Ics], Line, Col, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(88, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,88};
+yystate(87, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, [85|Ics], Line, Col, Tlen, _, _) ->
+    yystate(95, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, [C|Ics], Line, Col, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(87, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,87};
+yystate(86, [117|Ics], Line, Col, Tlen, _, _) ->
+    yystate(94, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, [C|Ics], Line, Col, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(86, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,86};
+yystate(85, Ics, Line, Col, Tlen, _, _) ->
+    {7,Tlen,Ics,Line,Col};
+yystate(84, [114|Ics], Line, Col, Tlen, _, _) ->
+    yystate(76, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, [C|Ics], Line, Col, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(84, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,84};
+yystate(83, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, [83|Ics], Line, Col, Tlen, _, _) ->
+    yystate(75, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, [C|Ics], Line, Col, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(83, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,83};
+yystate(82, [110|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, [C|Ics], Line, Col, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(82, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,82};
+yystate(81, [126|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(89, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(81, [61|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(89, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(81, Ics, Line, Col, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,Col,81};
+yystate(80, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, [84|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 83 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, [C|Ics], Line, Col, Tlen, _, _) when C >= 85, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(80, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,80};
+yystate(79, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [82|Ics], Line, Col, Tlen, _, _) ->
+    yystate(87, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [65|Ics], Line, Col, Tlen, _, _) ->
+    yystate(99, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [C|Ics], Line, Col, Tlen, _, _) when C >= 66, C =< 81 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [C|Ics], Line, Col, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(79, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,79};
+yystate(78, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, [82|Ics], Line, Col, Tlen, _, _) ->
+    yystate(70, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, [C|Ics], Line, Col, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(78, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,78};
+yystate(77, Ics, Line, Col, Tlen, _, _) ->
+    {6,Tlen,Ics,Line,Col};
+yystate(76, [101|Ics], Line, Col, Tlen, _, _) ->
+    yystate(68, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, [C|Ics], Line, Col, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(76, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,76};
+yystate(75, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, [85|Ics], Line, Col, Tlen, _, _) ->
+    yystate(67, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, [C|Ics], Line, Col, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(75, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,75};
+yystate(74, [111|Ics], Line, Col, Tlen, _, _) ->
+    yystate(82, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, [C|Ics], Line, Col, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(74, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,74};
+yystate(73, Ics, Line, Col, Tlen, _, _) ->
+    {11,Tlen,Ics,Line,Col};
+yystate(72, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, [83|Ics], Line, Col, Tlen, _, _) ->
+    yystate(80, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, [C|Ics], Line, Col, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(72, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,72};
+yystate(71, Ics, Line, Col, Tlen, _, _) ->
+    {4,Tlen,Ics,Line,Col};
+yystate(70, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(70, [65|Ics], Line, Col, Tlen, _, _) ->
+    yystate(62, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(70, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(70, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(70, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(70, [C|Ics], Line, Col, Tlen, _, _) when C >= 66, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(70, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(70, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,70};
+yystate(69, [114|Ics], Line, Col, Tlen, _, _) ->
+    yystate(61, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [97|Ics], Line, Col, Tlen, _, _) ->
+    yystate(37, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [C|Ics], Line, Col, Tlen, _, _) when C >= 98, C =< 113 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, [C|Ics], Line, Col, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(69, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,69};
+yystate(68, [113|Ics], Line, Col, Tlen, _, _) ->
+    yystate(60, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 112 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, [C|Ics], Line, Col, Tlen, _, _) when C >= 114, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(68, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,68};
+yystate(67, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, [76|Ics], Line, Col, Tlen, _, _) ->
+    yystate(59, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, [C|Ics], Line, Col, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(67, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,67};
+yystate(66, [115|Ics], Line, Col, Tlen, _, _) ->
+    yystate(74, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, [C|Ics], Line, Col, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(66, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,66};
+yystate(65, [39|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(73, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(65, [10|Ics], Line, _, Tlen, Action, Alen) ->
+    yystate(65, Ics, Line+1, 1, Tlen+1, Action, Alen);
+yystate(65, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 0, C =< 9 ->
+    yystate(65, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(65, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 11, C =< 38 ->
+    yystate(65, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(65, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 40 ->
+    yystate(65, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(65, Ics, Line, Col, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,Col,65};
+yystate(64, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, [69|Ics], Line, Col, Tlen, _, _) ->
+    yystate(72, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, [C|Ics], Line, Col, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(64, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,64};
+yystate(63, Ics, Line, Col, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,Col};
+yystate(62, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, [78|Ics], Line, Col, Tlen, _, _) ->
+    yystate(54, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 77 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, [C|Ics], Line, Col, Tlen, _, _) when C >= 79, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(62, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,62};
+yystate(61, [117|Ics], Line, Col, Tlen, _, _) ->
+    yystate(53, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, [C|Ics], Line, Col, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(61, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,61};
+yystate(60, [117|Ics], Line, Col, Tlen, _, _) ->
+    yystate(52, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, [C|Ics], Line, Col, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(60, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,60};
+yystate(59, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, [84|Ics], Line, Col, Tlen, _, _) ->
+    yystate(51, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 83 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, [C|Ics], Line, Col, Tlen, _, _) when C >= 85, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(59, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,59};
+yystate(58, [97|Ics], Line, Col, Tlen, _, _) ->
+    yystate(66, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(58, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(58, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(58, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(58, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(58, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(58, [C|Ics], Line, Col, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(58, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,58};
+yystate(57, [10|Ics], Line, _, Tlen, Action, Alen) ->
+    yystate(65, Ics, Line+1, 1, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 0, C =< 9 ->
+    yystate(65, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 11, C =< 38 ->
+    yystate(65, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 40 ->
+    yystate(65, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(57, Ics, Line, Col, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,Col,57};
+yystate(56, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, [85|Ics], Line, Col, Tlen, _, _) ->
+    yystate(64, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, [C|Ics], Line, Col, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(56, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,56};
+yystate(55, [100|Ics], Line, Col, Tlen, _, _) ->
+    yystate(22, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 99 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, [C|Ics], Line, Col, Tlen, _, _) when C >= 101, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(55, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,55};
+yystate(54, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [67|Ics], Line, Col, Tlen, _, _) ->
+    yystate(46, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [65|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [66|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [C|Ics], Line, Col, Tlen, _, _) when C >= 68, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(54, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,54};
+yystate(53, [101|Ics], Line, Col, Tlen, _, _) ->
+    yystate(45, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, [C|Ics], Line, Col, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(53, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,53};
+yystate(52, [101|Ics], Line, Col, Tlen, _, _) ->
+    yystate(44, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, [C|Ics], Line, Col, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(52, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,52};
+yystate(51, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(43, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(51, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(51, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(51, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(51, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(51, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(51, Ics, Line, Col, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,Col,51};
+yystate(50, [101|Ics], Line, Col, Tlen, _, _) ->
+    yystate(58, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, [C|Ics], Line, Col, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(50, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,50};
+yystate(49, Ics, Line, Col, Tlen, _, _) ->
+    {2,Tlen,Ics,Line,Col};
+yystate(48, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, [81|Ics], Line, Col, Tlen, _, _) ->
+    yystate(56, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 80 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, [C|Ics], Line, Col, Tlen, _, _) when C >= 82, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(48, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,48};
+yystate(47, [110|Ics], Line, Col, Tlen, _, _) ->
+    yystate(55, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, [C|Ics], Line, Col, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(47, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,47};
+yystate(46, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, [72|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 71 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, [C|Ics], Line, Col, Tlen, _, _) when C >= 73, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(46, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,46};
+yystate(45, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 10, Tlen);
+yystate(45, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 10, Tlen);
+yystate(45, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 10, Tlen);
+yystate(45, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 10, Tlen);
+yystate(45, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 10, Tlen);
+yystate(45, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 10, Tlen);
+yystate(45, Ics, Line, Col, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,Col,45};
+yystate(44, [115|Ics], Line, Col, Tlen, _, _) ->
+    yystate(36, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, [C|Ics], Line, Col, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(44, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,44};
+yystate(43, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, [82|Ics], Line, Col, Tlen, _, _) ->
+    yystate(35, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, [C|Ics], Line, Col, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(43, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,43};
+yystate(42, [114|Ics], Line, Col, Tlen, _, _) ->
+    yystate(50, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, [C|Ics], Line, Col, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(42, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,42};
+yystate(41, Ics, Line, Col, Tlen, _, _) ->
+    {3,Tlen,Ics,Line,Col};
+yystate(40, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, [69|Ics], Line, Col, Tlen, _, _) ->
+    yystate(48, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, [C|Ics], Line, Col, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(40, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,40};
+yystate(39, [104|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 103 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, [C|Ics], Line, Col, Tlen, _, _) when C >= 105, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(39, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,39};
+yystate(38, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, [78|Ics], Line, Col, Tlen, _, _) ->
+    yystate(30, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 77 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, [C|Ics], Line, Col, Tlen, _, _) when C >= 79, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(38, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,38};
+yystate(37, [103|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, [C|Ics], Line, Col, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(37, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,37};
+yystate(36, [116|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, [C|Ics], Line, Col, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(36, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,36};
+yystate(35, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, [69|Ics], Line, Col, Tlen, _, _) ->
+    yystate(27, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 68 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, [C|Ics], Line, Col, Tlen, _, _) when C >= 70, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(35, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,35};
+yystate(34, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(42, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(34, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(34, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(34, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(34, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(34, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(34, Ics, Line, Col, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,Col,34};
+yystate(33, Ics, Line, Col, Tlen, _, _) ->
+    {8,Tlen,Ics,Line,Col};
+yystate(32, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, [82|Ics], Line, Col, Tlen, _, _) ->
+    yystate(40, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 81 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, [C|Ics], Line, Col, Tlen, _, _) when C >= 83, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(32, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,32};
+yystate(31, [99|Ics], Line, Col, Tlen, _, _) ->
+    yystate(39, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [97|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [98|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, [C|Ics], Line, Col, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(31, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,31};
+yystate(30, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, [68|Ics], Line, Col, Tlen, _, _) ->
+    yystate(22, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 67 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, [C|Ics], Line, Col, Tlen, _, _) when C >= 69, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(30, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,30};
+yystate(29, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(29, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(29, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(29, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(29, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(29, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 9, Tlen);
+yystate(29, Ics, Line, Col, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,Col,29};
+yystate(28, [114|Ics], Line, Col, Tlen, _, _) ->
+    yystate(22, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, [C|Ics], Line, Col, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(28, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,28};
+yystate(27, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(27, [65|Ics], Line, Col, Tlen, _, _) ->
+    yystate(19, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(27, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(27, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(27, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(27, [C|Ics], Line, Col, Tlen, _, _) when C >= 66, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(27, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(27, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,27};
+yystate(26, [116|Ics], Line, Col, Tlen, _, _) ->
+    yystate(34, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, [C|Ics], Line, Col, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(26, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,26};
+yystate(25, [48|Ics], Line, Col, Tlen, Action, Alen) ->
+    yystate(17, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(25, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 49, C =< 57 ->
+    yystate(6, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(25, Ics, Line, Col, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,Col,25};
+yystate(24, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(32, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(24, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(24, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(24, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(24, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(24, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(24, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,24};
+yystate(23, [110|Ics], Line, Col, Tlen, _, _) ->
+    yystate(31, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, [C|Ics], Line, Col, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(23, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,23};
+yystate(22, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 1, Tlen);
+yystate(22, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 1, Tlen);
+yystate(22, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 1, Tlen);
+yystate(22, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 1, Tlen);
+yystate(22, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 1, Tlen);
+yystate(22, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 1, Tlen);
+yystate(22, Ics, Line, Col, Tlen, _, _) ->
+    {1,Tlen,Ics,Line,Col,22};
+yystate(21, Ics, Line, Col, Tlen, _, _) ->
+    {15,Tlen,Ics,Line,Col};
+yystate(20, [97|Ics], Line, Col, Tlen, _, _) ->
+    yystate(12, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(20, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(20, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(20, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(20, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(20, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(20, [C|Ics], Line, Col, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(20, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,20};
+yystate(19, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, [83|Ics], Line, Col, Tlen, _, _) ->
+    yystate(11, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 82 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, [C|Ics], Line, Col, Tlen, _, _) when C >= 84, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(19, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,19};
+yystate(18, [108|Ics], Line, Col, Tlen, _, _) ->
+    yystate(26, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, [C|Ics], Line, Col, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(18, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,18};
+yystate(17, Ics, Line, Col, Tlen, _, _) ->
+    {12,Tlen,Ics,Line,Col};
+yystate(16, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, [76|Ics], Line, Col, Tlen, _, _) ->
+    yystate(24, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, [C|Ics], Line, Col, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(16, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,16};
+yystate(15, [97|Ics], Line, Col, Tlen, _, _) ->
+    yystate(23, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(15, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(15, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(15, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(15, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(15, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(15, [C|Ics], Line, Col, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(15, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,15};
+yystate(14, [126|Ics], Line, Col, Tlen, _, _) ->
+    yystate(89, Ics, Line, Col, Tlen+1, 0, Tlen);
+yystate(14, Ics, Line, Col, Tlen, _, _) ->
+    {0,Tlen,Ics,Line,Col,14};
+yystate(13, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(13, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(13, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(13, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(13, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(13, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(13, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,13};
+yystate(12, [108|Ics], Line, Col, Tlen, _, _) ->
+    yystate(4, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, [C|Ics], Line, Col, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(12, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,12};
+yystate(11, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, [79|Ics], Line, Col, Tlen, _, _) ->
+    yystate(3, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 78 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, [C|Ics], Line, Col, Tlen, _, _) when C >= 80, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(11, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,11};
+yystate(10, [117|Ics], Line, Col, Tlen, _, _) ->
+    yystate(18, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, [C|Ics], Line, Col, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(10, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,10};
+yystate(9, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(9, Ics, Line, Col, Tlen+1, 13, Tlen);
+yystate(9, Ics, Line, Col, Tlen, _, _) ->
+    {13,Tlen,Ics,Line,Col,9};
+yystate(8, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, [76|Ics], Line, Col, Tlen, _, _) ->
+    yystate(16, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 75 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, [C|Ics], Line, Col, Tlen, _, _) when C >= 77, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(8, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,8};
+yystate(7, [114|Ics], Line, Col, Tlen, _, _) ->
+    yystate(15, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, [C|Ics], Line, Col, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(7, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,7};
+yystate(6, [46|Ics], Line, Col, Tlen, _, _) ->
+    yystate(1, Ics, Line, Col, Tlen+1, 12, Tlen);
+yystate(6, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(6, Ics, Line, Col, Tlen+1, 12, Tlen);
+yystate(6, Ics, Line, Col, Tlen, _, _) ->
+    {12,Tlen,Ics,Line,Col,6};
+yystate(5, [101|Ics], Line, Col, Tlen, _, _) ->
+    yystate(2, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, [C|Ics], Line, Col, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(5, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,5};
+yystate(4, [115|Ics], Line, Col, Tlen, _, _) ->
+    yystate(53, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, [C|Ics], Line, Col, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(4, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,4};
+yystate(3, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, [78|Ics], Line, Col, Tlen, _, _) ->
+    yystate(29, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 77 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, [C|Ics], Line, Col, Tlen, _, _) when C >= 79, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(3, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,3};
+yystate(2, [115|Ics], Line, Col, Tlen, _, _) ->
+    yystate(10, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, [C|Ics], Line, Col, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(2, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,2};
+yystate(1, [C|Ics], Line, Col, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(9, Ics, Line, Col, Tlen+1, Action, Alen);
+yystate(1, Ics, Line, Col, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,Col,1};
+yystate(0, [95|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, [85|Ics], Line, Col, Tlen, _, _) ->
+    yystate(8, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, [58|Ics], Line, Col, Tlen, _, _) ->
+    yystate(21, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, [45|Ics], Line, Col, Tlen, _, _) ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, [C|Ics], Line, Col, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, [C|Ics], Line, Col, Tlen, _, _) when C >= 65, C =< 84 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, [C|Ics], Line, Col, Tlen, _, _) when C >= 86, C =< 90 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, [C|Ics], Line, Col, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(13, Ics, Line, Col, Tlen+1, 14, Tlen);
+yystate(0, Ics, Line, Col, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,Col,0};
+yystate(S, Ics, Line, Col, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,Col,S}.
 
-%% yyaction(Action, TokenLength, TokenChars, TokenLine) ->
+%% yyaction(Action, TokenLength, TokenChars, TokenLine, TokenCol) ->
 %% {token,Token} | {end_token, Token} | skip_token | {error,String}.
 %% Generated action function.
 
-yyaction(0, TokenLen, YYtcs, TokenLine) ->
+yyaction(0, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_0(TokenChars, TokenLine);
-yyaction(1, TokenLen, YYtcs, TokenLine) ->
+yyaction(1, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_1(TokenChars, TokenLine);
-yyaction(2, _, _, TokenLine) ->
+yyaction(2, _, _, TokenLine, _) ->
     yyaction_2(TokenLine);
-yyaction(3, _, _, TokenLine) ->
+yyaction(3, _, _, TokenLine, _) ->
     yyaction_3(TokenLine);
-yyaction(4, _, _, TokenLine) ->
+yyaction(4, _, _, TokenLine, _) ->
     yyaction_4(TokenLine);
-yyaction(5, _, _, TokenLine) ->
+yyaction(5, _, _, TokenLine, _) ->
     yyaction_5(TokenLine);
-yyaction(6, _, _, TokenLine) ->
+yyaction(6, _, _, TokenLine, _) ->
     yyaction_6(TokenLine);
-yyaction(7, _, _, TokenLine) ->
+yyaction(7, _, _, TokenLine, _) ->
     yyaction_7(TokenLine);
-yyaction(8, _, _, TokenLine) ->
+yyaction(8, _, _, TokenLine, _) ->
     yyaction_8(TokenLine);
-yyaction(9, TokenLen, YYtcs, TokenLine) ->
+yyaction(9, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_9(TokenChars, TokenLine);
-yyaction(10, TokenLen, YYtcs, TokenLine) ->
+yyaction(10, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_10(TokenChars, TokenLine);
-yyaction(11, TokenLen, YYtcs, TokenLine) ->
+yyaction(11, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_11(TokenChars, TokenLine);
-yyaction(12, TokenLen, YYtcs, TokenLine) ->
+yyaction(12, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_12(TokenChars, TokenLine);
-yyaction(13, TokenLen, YYtcs, TokenLine) ->
+yyaction(13, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_13(TokenChars, TokenLine);
-yyaction(14, TokenLen, YYtcs, TokenLine) ->
+yyaction(14, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_14(TokenChars, TokenLine);
-yyaction(15, TokenLen, YYtcs, TokenLine) ->
+yyaction(15, TokenLen, YYtcs, TokenLine, _) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_15(TokenChars, TokenLine);
-yyaction(16, _, _, _) ->
+yyaction(16, _, _, _, _) ->
     yyaction_16();
-yyaction(_, _, _, _) -> error.
+yyaction(_, _, _, _, _) -> error.
 
 -compile({inline,yyaction_0/2}).
 -file("src/when_lexer.xrl", 23).
@@ -2031,5 +2097,4 @@ yyaction_15(TokenChars, TokenLine) ->
 -file("src/when_lexer.xrl", 39).
 yyaction_16() ->
      skip_token .
-
--file("/usr/local/lib/erlang/lib/parsetools-2.1.6/include/leexinc.hrl", 313).
+-file("/usr/local/lib/erlang/lib/parsetools-2.5/include/leexinc.hrl", 344).


### PR DESCRIPTION
The newer cloud agents use Erlang/OTP 25 as the default version so this library needs to be updated for init jobs to run on those cloud agents.

This PR updates a library as far as possible according to [this](https://hexdocs.pm/elixir/1.17.2/compatibility-and-deprecations.html#between-elixir-and-erlang-otp) compatibility matrix while maintaining the support for Erlang/OTP 24 that is used on older agents.