### PR TITLE
Fix issues with running test docker images on tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ APP_NAME=when
 
 export MIX_ENV?=dev
 
-BRANCH=$(shell git rev-parse --abbrev-ref HEAD | sed 's/[^a-z]//g')
+BRANCH := $(shell branch=$$(git rev-parse --abbrev-ref HEAD); \
+                if [ "$$branch" = "HEAD" ]; then \
+                    echo "master"; \
+                else \
+                    echo "$$branch" | sed 's/[^a-z]//g'; \
+                fi)
 SECURITY_TOOLBOX_BRANCH?=master
 SECURITY_TOOLBOX_TMP_DIR?=/tmp/security-toolbox
 REGISTRY_HOST?=local


### PR DESCRIPTION
The BRANCH value on tags ends up being an empty string that breaks running docker images because of the image name's invalid format, as seen [here](https://semaphore.semaphoreci.com/jobs/9235417a-171c-4e76-a0df-55337d603869).
This change adds a fallback to `master` for BRANCH value.