### PR TITLE
ci: fix daily build

### DIFF
--- a/.semaphore/daily-build.yml
+++ b/.semaphore/daily-build.yml
@@ -3,7 +3,7 @@ name: Build & Test
 agent:
   machine:
     type: e2-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 auto_cancel:
   running:
     when: 'true'

--- a/.semaphore/daily-build.yml
+++ b/.semaphore/daily-build.yml
@@ -17,6 +17,10 @@ blocks:
           value: test
         - name: DOCKER_BUILDKIT
           value: "1"
+        - name: ERLANG_VERSION
+          value: "27"
+        - name: ELIXIR_VERSION
+          value: "1.17.3"
       prologue:
         commands:
           - checkout


### PR DESCRIPTION
Specify ERLANG and ELIXIR version for daily build pipeline.

It's [failing](https://semaphore.semaphoreci.com/workflows/6f9ef436-ade3-46ec-bdf9-76be6b15f668?pipeline_id=09068b12-72d5-4a45-a2ba-08da01abecbe) at the moment. 